### PR TITLE
support "psr/http-message" v2 version

### DIFF
--- a/.github/workflows/ci-phpunit.yml
+++ b/.github/workflows/ci-phpunit.yml
@@ -58,8 +58,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - symfony: '4'
-            php-version: '7.1'
           - symfony: '5'
             php-version: '7.4'
           - symfony: '6'

--- a/.github/workflows/ci-phpunit.yml
+++ b/.github/workflows/ci-phpunit.yml
@@ -11,12 +11,12 @@ on:
 
 jobs:
   phpunit-tests:
-    name: PHP ${{ matrix.php }} Latest
+    name: PHP ${{ matrix.php-version }} Latest
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        php: [ '7.4','8.0','8.1','8.2' ]
+        php-version: [ '7.4','8.0','8.1','8.2' ]
 
     steps:
       - name: Checkout
@@ -26,7 +26,7 @@ jobs:
         id: setup-php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: ${{ matrix.php-version }}
           extensions: mbstring, intl, curl
 
       - name: Print PHP version

--- a/.github/workflows/ci-phpunit.yml
+++ b/.github/workflows/ci-phpunit.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        php-versions: [ '7.4','8.0','8.1','8.2' ]
+        php: [ '7.4','8.0','8.1','8.2' ]
 
     steps:
       - name: Checkout
@@ -26,7 +26,7 @@ jobs:
         id: setup-php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php }}
           extensions: mbstring, intl, curl
 
       - name: Print PHP version

--- a/.github/workflows/ci-phpunit.yml
+++ b/.github/workflows/ci-phpunit.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   phpunit-tests:
+    name: PHP ${{ matrix.php }} Latest
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -49,4 +50,38 @@ jobs:
         run: composer install --prefer-dist --no-progress
 
       - name: Run phpunit tests
+        run: composer test
+
+  symfony:
+    name: Symfony ${{ matrix.symfony }} LTS
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - symfony: '4'
+            php-version: '7.1'
+          - symfony: '5'
+            php-version: '7.4'
+          - symfony: '6'
+            php-version: '8.2'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer config --no-plugins allow-plugins.symfony/flex true
+          composer require --no-update --no-interaction --no-progress symfony/flex
+          composer config extra.symfony.require ${{ matrix.symfony}}
+          composer update --prefer-dist --no-interaction --prefer-stable --prefer-lowest --no-progress
+
+      - name: Execute tests
         run: composer test

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "php": "^7.4 || ^8.0",
     "ext-curl": "*",
     "ext-json": "*",
-    "psr/http-message": "^1.0",
+    "psr/http-message": "^1.0 || ^2.0",
     "psr/http-client-implementation": "^1.0",
     "php-http/client-common": "^2.0",
     "php-http/httplug": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "symfony/mailer": "^5.4|^6.0",
     "phpunit/phpunit": "^9",
     "nyholm/psr7": "^1.5",
-    "vimeo/psalm": "^5.0"
+    "vimeo/psalm": "^4.0 || ^5.0"
   },
   "suggest": {
     "nyholm/psr7": "PSR-7 message implementation",

--- a/tests/Api/Sandbox/InboxTest.php
+++ b/tests/Api/Sandbox/InboxTest.php
@@ -308,7 +308,7 @@ class InboxTest extends MailtrapTestCase
         $this->assertInstanceOf(Response::class, $response);
         $this->assertArrayHasKey('id', $responseData);
         $this->assertEquals(self::FAKE_INBOX_ID, $responseData['id']);
-        $this->assertEquals($expectedData['email_username_enabled'], $responseData['username']);
+        $this->assertEquals($expectedData['email_username_enabled'], $responseData['email_username_enabled']);
     }
 
     public function testResetEmailAddress(): void


### PR DESCRIPTION
## Motivation
Support for the new version of the PSR [PHP Standards Recommendations] (no breaking changes)

## Changes

* Add support of psr/http-message v2 
* Run tests with Symfony framework (GitHub actions) 

## How to test
```
composer test
```