### PR TITLE
Support 'reply-to' header

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ $mailtrap = new MailtrapClient(new Config($apiKey));
 
 $email = (new Email())
     ->from(new Address('example@your-domain-here.com', 'Mailtrap Test'))
+    ->replyTo(new Address('reply@your-domain-here.com'))
     ->to(new Address('email@example.com', 'Jon'))
+    ->priority(Email::PRIORITY_HIGH)
     ->cc('mailtrapqa@example.com')
     ->addCc('staging@example.com')
     ->bcc('mailtrapdev@example.com')

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "php-http/client-common": "^2.0",
     "php-http/httplug": "^2.0",
     "php-http/discovery": "^1.0",
+    "php-http/message-factory": "^1.0",
     "symfony/mime": "^5.4|^6.0",
     "egulias/email-validator": "^2.1.10|^3.1|^4"
   },

--- a/examples/sandbox/emails.php
+++ b/examples/sandbox/emails.php
@@ -29,6 +29,7 @@ try {
 
     $email = (new Email())
         ->from(new Address('mailtrap@example.com', 'Mailtrap Test'))
+        ->replyTo(new Address('reply@example.com'))
         ->to(new Address('email@example.com', 'Jon'))
         ->cc('mailtrapqa@example.com')
         ->addCc('staging@example.com')

--- a/examples/sending/emails.php
+++ b/examples/sending/emails.php
@@ -31,7 +31,9 @@ try {
 
     $email = (new Email())
         ->from(new Address('example@YOUR-DOMAIN-HERE.com', 'Mailtrap Test')) // <--- you should use your domain here that you installed in the mailtrap.io admin area (otherwise you will get 401)
+        ->replyTo(new Address('reply@YOUR-DOMAIN-HERE.com'))
         ->to(new Address('email@example.com', 'Jon'))
+        ->priority(Email::PRIORITY_HIGH)
         ->cc('mailtrapqa@example.com')
         ->addCc('staging@example.com')
         ->bcc('mailtrapdev@example.com')
@@ -91,6 +93,7 @@ try {
 
     $email = (new Email())
         ->from(new Address('example@YOUR-DOMAIN-HERE.com', 'Mailtrap Test')) // <--- you should use your domain here that you installed in the mailtrap.io admin area (otherwise you will get 401)
+        ->replyTo(new Address('reply@YOUR-DOMAIN-HERE.com'))
         ->to(new Address('example@gmail.com', 'Jon'))
     ;
 

--- a/src/Api/AbstractEmails.php
+++ b/src/Api/AbstractEmails.php
@@ -50,7 +50,7 @@ abstract class AbstractEmails extends AbstractApi
             $payload['attachments'] = $this->getAttachments($email);
         }
 
-        $headersToBypass = ['received', 'from', 'to', 'cc', 'bcc', 'subject', 'content-type', 'reply-to'];
+        $headersToBypass = ['received', 'from', 'to', 'cc', 'bcc', 'subject', 'content-type'];
         foreach ($email->getHeaders()->all() as $name => $header) {
             if (in_array($name, $headersToBypass, true)) {
                 continue;

--- a/tests/Api/Sandbox/EmailsTest.php
+++ b/tests/Api/Sandbox/EmailsTest.php
@@ -54,7 +54,9 @@ final class EmailsTest extends MailtrapTestCase
 
         $email = new Email();
         $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+            ->replyTo(new Address('reply@example.com'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
+            ->priority(Email::PRIORITY_HIGH)
             ->bcc('baz@example.com')
             ->subject('Best practices of building HTML emails')
             ->text('Some text')
@@ -82,7 +84,9 @@ final class EmailsTest extends MailtrapTestCase
                 'text' => 'Some text',
                 'html' => '<p>Some text</p>',
                 'headers' => [
-                    'X-Message-Source' => 'dev.mydomain.com'
+                    'X-Message-Source' => 'dev.mydomain.com',
+                    'Reply-To' => 'reply@example.com',
+                    'X-Priority' => '2 (High)',
                 ]
             ])
             ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedData)));

--- a/tests/Api/Sending/EmailsTest.php
+++ b/tests/Api/Sending/EmailsTest.php
@@ -59,7 +59,9 @@ final class EmailsTest extends MailtrapTestCase
 
         $email = new Email();
         $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+            ->replyTo(new Address('reply@example.com'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
+            ->priority(Email::PRIORITY_HIGH)
             ->bcc('baz@example.com')
             ->subject('Best practices of building HTML emails')
             ->text('Some text')
@@ -87,7 +89,9 @@ final class EmailsTest extends MailtrapTestCase
                 'text' => 'Some text',
                 'html' => '<p>Some text</p>',
                 'headers' => [
-                    'X-Message-Source' => 'dev.mydomain.com'
+                    'X-Message-Source' => 'dev.mydomain.com',
+                    'Reply-To' => 'reply@example.com',
+                    'X-Priority' => '2 (High)',
                 ]
             ])
             ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedData)));


### PR DESCRIPTION
## Motivation
Support  'reply-to' mail header

## Changes

- Add support  'reply-to' mail header
- Rollback 'php-http/message-factory' library (needs for PHP 7.4)

## How to test

```
composer test
```
