### PR TITLE
Use Psr18ClientDiscovery instead of deprecated HttpClientDiscovery (issue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.7.3] - 2024-01-30
+
+- Use Psr18ClientDiscovery instead of deprecated HttpClientDiscovery
+
 ## [1.7.0] - 2023-05-16
 
 - Support sandbox message endpoints. Examples [here](examples/sandbox/messages.php)

--- a/src/HttpClient/HttpClientBuilder.php
+++ b/src/HttpClient/HttpClientBuilder.php
@@ -8,8 +8,8 @@ use Http\Client\Common\HttpMethodsClient;
 use Http\Client\Common\HttpMethodsClientInterface;
 use Http\Client\Common\Plugin;
 use Http\Client\Common\PluginClientFactory;
-use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Http\Message\Authentication\Bearer;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -33,7 +33,7 @@ class HttpClientBuilder implements HttpClientBuilderInterface
         StreamFactoryInterface $streamFactory = null
     ) {
         $this->apiToken = $apiToken;
-        $this->httpClient = $httpClient ?? HttpClientDiscovery::find();
+        $this->httpClient = $httpClient ?? Psr18ClientDiscovery::find();
         $this->requestFactory = $requestFactory ?? Psr17FactoryDiscovery::findRequestFactory();
         $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();
     }


### PR DESCRIPTION
## Motivation

[The issue with discovery package](https://github.com/railsware/mailtrap-php/issues/18)
```
php 8.2

Caught exception: No HTTPlug clients found. Make sure to install a package providing "php-http/client-implementation". Example: "php-http/guzzle6-adapter".
```
php-http/discovery [changelog](https://github.com/php-http/discovery/blob/1.x/CHANGELOG.md)

## Changes

- Use Psr18ClientDiscovery instead of deprecated HttpClientDiscovery

## How to test
Install the fixed version and try to send any email on PHP 8.2 (example from the readme)
```
composer require railsware/mailtrap-php:dev-fix/remove-deprecated-method symfony/http-client nyholm/psr7
```
