### PR TITLE
Upgrade SDK v.2

### DIFF
--- a/.github/workflows/ci-phpunit.yml
+++ b/.github/workflows/ci-phpunit.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        php-version: [ '7.4','8.0','8.1','8.2','8.3' ]
+        php-version: [ '8.0','8.1','8.2','8.3' ]
 
     steps:
       - name: Checkout
@@ -58,8 +58,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - symfony: '5'
-            php-version: '7.4'
           - symfony: '6'
             php-version: '8.2'
           - symfony: '7'

--- a/.github/workflows/ci-psalm.yaml
+++ b/.github/workflows/ci-psalm.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        php-versions: [ '7.4','8.0','8.1','8.2','8.3' ]
+        php-versions: [ '8.0','8.1','8.2','8.3' ]
 
     steps:
       - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php-http/discovery": "^1.0",
     "php-http/message-factory": "^1.0",
     "symfony/mime": "^6.0|^7.0",
-    "egulias/email-validator": "^3.1|^4"
+    "egulias/email-validator": "^2.1.10|^3.1|^4"
   },
   "require-dev": {
     "symfony/http-client": "^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/railsware/mailtrap-php",
   "license": "MIT",
   "require": {
-    "php": "^7.4 || ^8.0",
+    "php": "^8.0",
     "ext-curl": "*",
     "ext-json": "*",
     "psr/http-message": "^1.0 || ^2.0",
@@ -14,15 +14,16 @@
     "php-http/httplug": "^2.0",
     "php-http/discovery": "^1.0",
     "php-http/message-factory": "^1.0",
-    "symfony/mime": "^5.4|^6.0|^7.0",
-    "egulias/email-validator": "^2.1.10|^3.1|^4"
+    "symfony/mime": "^6.0|^7.0",
+    "egulias/email-validator": "^3|^4"
   },
   "require-dev": {
-    "symfony/http-client": "^5.4|^6.0|^7.0",
-    "symfony/mailer": "^5.4|^6.0|^7.0",
+    "symfony/http-client": "^6.0|^7.0",
+    "symfony/mailer": "^6.0|^7.0",
     "phpunit/phpunit": "^9",
     "nyholm/psr7": "^1.5",
-    "vimeo/psalm": "^4.0 || ^5.0"
+    "vimeo/psalm": "^5.0",
+    "rector/rector": "dev-main"
   },
   "suggest": {
     "nyholm/psr7": "PSR-7 message implementation",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "php-http/discovery": "^1.0",
     "php-http/message-factory": "^1.0",
     "symfony/mime": "^6.0|^7.0",
-    "egulias/email-validator": "^3|^4"
+    "egulias/email-validator": "^3.1|^4"
   },
   "require-dev": {
     "symfony/http-client": "^6.0|^7.0",

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,7 @@
     "symfony/mailer": "^6.0|^7.0",
     "phpunit/phpunit": "^9",
     "nyholm/psr7": "^1.5",
-    "vimeo/psalm": "^5.0",
-    "rector/rector": "dev-main"
+    "vimeo/psalm": "^5.0"
   },
   "suggest": {
     "nyholm/psr7": "PSR-7 message implementation",

--- a/src/AbstractMailtrapClient.php
+++ b/src/AbstractMailtrapClient.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Mailtrap;
 
-use Mailtrap\Api\AbstractApi;
 use Mailtrap\Exception\BadMethodCallException;
 use Mailtrap\Exception\InvalidArgumentException;
 
@@ -13,18 +12,15 @@ use Mailtrap\Exception\InvalidArgumentException;
  */
 abstract class AbstractMailtrapClient implements MailtrapClientInterface
 {
-    protected ConfigInterface $config;
-
-    public function __construct(ConfigInterface $config)
+    public function __construct(protected ConfigInterface $config)
     {
-        $this->config = $config;
     }
 
     public function __call(string $name, array $arguments)
     {
         try {
             return $this->initByName($name);
-        } catch (InvalidArgumentException $e) {
+        } catch (InvalidArgumentException) {
             throw new BadMethodCallException(sprintf('%s -> undefined method called: "%s"', static::class, $name));
         }
     }

--- a/src/Api/AbstractApi.php
+++ b/src/Api/AbstractApi.php
@@ -117,7 +117,7 @@ abstract class AbstractApi
      *
      * @return string
      */
-    private function jsonEncode($value, int $flags = null, int $maxDepth = 512): string
+    private function jsonEncode(mixed $value, int $flags = null, int $maxDepth = 512): string
     {
         $flags ??= \JSON_HEX_TAG | \JSON_HEX_APOS | \JSON_HEX_AMP | \JSON_HEX_QUOT | \JSON_PRESERVE_ZERO_FRACTION;
 

--- a/src/Api/Sandbox/Project.php
+++ b/src/Api/Sandbox/Project.php
@@ -42,7 +42,7 @@ class Project extends AbstractApi implements SandboxInterface
     }
 
     /**
-     * Create project
+     * Create a project
      *
      * @param int    $accountId
      * @param string $projectName

--- a/src/Bridge/Transport/MailtrapApiTransport.php
+++ b/src/Bridge/Transport/MailtrapApiTransport.php
@@ -23,22 +23,13 @@ use Symfony\Component\Mime\MessageConverter;
  */
 class MailtrapApiTransport extends AbstractTransport
 {
-    /**
-     * @var MailtrapSendingClient|MailtrapSandboxClient
-     */
-    private MailtrapClientInterface $mailtrapClient;
-    private ?int $inboxId;
-
     public function __construct(
-        MailtrapClientInterface $mailtrapClient,
-        int $inboxId = null,
+        private MailtrapClientInterface $mailtrapClient,
+        private ?int $inboxId = null,
         EventDispatcherInterface $dispatcher = null,
         LoggerInterface $logger = null
     ) {
         parent::__construct($dispatcher, $logger);
-
-        $this->mailtrapClient = $mailtrapClient;
-        $this->inboxId = $inboxId;
     }
 
     public function __toString(): string

--- a/src/Config.php
+++ b/src/Config.php
@@ -15,7 +15,6 @@ use Psr\Http\Message\StreamFactoryInterface;
  */
 class Config implements ConfigInterface
 {
-    private string $apiToken;
     private ?ClientInterface $httpClient = null;
     private ?HttpClientBuilderInterface $httpClientBuilder = null;
     private ?RequestFactoryInterface $requestFactory = null;
@@ -23,9 +22,8 @@ class Config implements ConfigInterface
     private ?string $host = null;
     private bool $responseThrowOnError = true;
 
-    public function __construct(string $apiToken)
+    public function __construct(private string $apiToken)
     {
-        $this->apiToken = $apiToken;
     }
 
     public function getApiToken(): string

--- a/src/DTO/Request/Inbox.php
+++ b/src/DTO/Request/Inbox.php
@@ -7,13 +7,8 @@ namespace Mailtrap\DTO\Request;
  */
 class Inbox implements RequestInterface
 {
-    private ?string $name;
-    private ?string $emailUsername;
-
-    public function __construct(string $name = null, string $emailUsername = null)
+    public function __construct(private ?string $name = null, private ?string $emailUsername = null)
     {
-        $this->name = $name;
-        $this->emailUsername = $emailUsername;
     }
 
     /**

--- a/src/DTO/Request/Permission/CreateOrUpdatePermission.php
+++ b/src/DTO/Request/Permission/CreateOrUpdatePermission.php
@@ -14,11 +14,11 @@ final class CreateOrUpdatePermission implements PermissionInterface
     private string $accessLevel;
 
     /**
-     * @param string|int $resourceId
+     * @param int|string $resourceId
      * @param string     $resourceType
-     * @param string|int $accessLevel
+     * @param int|string $accessLevel
      */
-    public function __construct($resourceId, string $resourceType, $accessLevel)
+    public function __construct(int|string $resourceId, string $resourceType, int|string $accessLevel)
     {
         $this->resourceId = (string) $resourceId;
         $this->resourceType = $resourceType;

--- a/src/DTO/Request/Permission/DestroyPermission.php
+++ b/src/DTO/Request/Permission/DestroyPermission.php
@@ -13,10 +13,10 @@ final class DestroyPermission implements PermissionInterface
     private string $resourceType;
 
     /**
-     * @param string|int $resourceId
+     * @param int|string $resourceId
      * @param string     $resourceType
      */
-    public function __construct($resourceId, string $resourceType)
+    public function __construct(int|string $resourceId, string $resourceType)
     {
         $this->resourceId = (string) $resourceId;
         $this->resourceType = $resourceType;

--- a/src/Exception/HttpClientException.php
+++ b/src/Exception/HttpClientException.php
@@ -27,7 +27,7 @@ class HttpClientException extends HttpException
 
         try {
             $body = ResponseHelper::toArray($response);
-        } catch (JsonException|InvalidTypeException $e) {
+        } catch (JsonException|InvalidTypeException) {
             $body['error'] = $response->getBody()->__toString();
         }
 
@@ -56,11 +56,11 @@ class HttpClientException extends HttpException
      * {"errors": {"name":["is too short (minimum is 2 characters)"]}}      422 errorS (array with key name)
      *
      *
-     * @param string|array $errors
+     * @param array|string $errors
      *
      * @return string
      */
-    public static function getErrorMsg($errors): string
+    public static function getErrorMsg(array|string $errors): string
     {
         $errorMsg = '';
         if (is_array($errors)) {

--- a/src/Helper/ResponseHelper.php
+++ b/src/Helper/ResponseHelper.php
@@ -18,7 +18,7 @@ final class ResponseHelper
      */
     public static function toArray(ResponseInterface $response): array
     {
-        if (strpos($response->getHeaderLine('Content-Type'), 'application/json') === false) {
+        if (!str_contains($response->getHeaderLine('Content-Type'), 'application/json')) {
             // This can happen when the URL structure changes and the response returns a 404 HTML page. (rare case)
             throw new InvalidTypeException(sprintf(
                 'Invalid content type in response. "%s" type expected, but received "%s"',

--- a/src/HttpClient/HttpClientBuilder.php
+++ b/src/HttpClient/HttpClientBuilder.php
@@ -24,15 +24,13 @@ class HttpClientBuilder implements HttpClientBuilderInterface
     private RequestFactoryInterface $requestFactory;
     private StreamFactoryInterface $streamFactory;
     private ?HttpMethodsClientInterface $pluginClient = null;
-    private string $apiToken;
 
     public function __construct(
-        string $apiToken,
+        private string $apiToken,
         ClientInterface $httpClient = null,
         RequestFactoryInterface $requestFactory = null,
         StreamFactoryInterface $streamFactory = null
     ) {
-        $this->apiToken = $apiToken;
         $this->httpClient = $httpClient ?? Psr18ClientDiscovery::find();
         $this->requestFactory = $requestFactory ?? Psr17FactoryDiscovery::findRequestFactory();
         $this->streamFactory = $streamFactory ?? Psr17FactoryDiscovery::findStreamFactory();

--- a/src/MailtrapBulkSendingClient.php
+++ b/src/MailtrapBulkSendingClient.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Mailtrap;
 
-use Mailtrap\Api;
-
 /**
  * @method  Api\BulkSending\Emails   emails
  *

--- a/src/MailtrapGeneralClient.php
+++ b/src/MailtrapGeneralClient.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Mailtrap;
 
-use Mailtrap\Api;
-
 /**
  * @method Api\General\Account      accounts
  * @method Api\General\User         users

--- a/src/MailtrapSandboxClient.php
+++ b/src/MailtrapSandboxClient.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Mailtrap;
 
-use Mailtrap\Api;
-
 /**
  * @method  Api\Sandbox\Emails      emails
  * @method  Api\Sandbox\Project     projects

--- a/src/MailtrapSendingClient.php
+++ b/src/MailtrapSendingClient.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Mailtrap;
 
-use Mailtrap\Api;
-
 /**
  * @method  Api\Sending\Emails   emails
  *

--- a/tests/Api/AbstractEmailsTest.php
+++ b/tests/Api/AbstractEmailsTest.php
@@ -41,7 +41,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
         ];
 
         $email = new Email();
-        $email->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'))
+        $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
             ->replyTo(new Address('reply@example.com'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
             ->priority(Email::PRIORITY_HIGH)
@@ -59,7 +59,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with($this->getHost() . '/api/send', [], [
                 'from' => [
-                    'email' => 'phpnuit@example.com',
+                    'email' => 'foo@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [[
@@ -105,7 +105,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
         );
 
         $email = new Email();
-        $email->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'))
+        $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
             ->text('Some text')
             ->html('<p>Some text</p>')
         ;
@@ -117,7 +117,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with($this->getHost() . '/api/send', [], [
                 'from' => [
-                    'email' => 'phpnuit@example.com',
+                    'email' => 'foo@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [],
@@ -142,7 +142,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
         ];
 
         $email = (new Email())
-            ->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'))
+            ->from(new Address('foo@example.com', 'Ms. Foo Bar'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
         ;
 
@@ -160,7 +160,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with($this->getHost() . '/api/send', [], [
                 'from' => [
-                    'email' => 'phpnuit@example.com',
+                    'email' => 'foo@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [[
@@ -190,7 +190,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
     public function testAttachments(): void
     {
         $email = (new Email())
-            ->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'))
+            ->from(new Address('foo@example.com', 'Ms. Foo Bar'))
             ->attach('fake_body', 'fakeFile.jpg', 'image/jpg')
         ;
 
@@ -212,7 +212,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testHeaders($name, $value): void
     {
-        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()->addTextHeader($name, $value);
 
         $method = new \ReflectionMethod(Emails::class, 'getPayload');
@@ -229,7 +229,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testCustomVariables($name, $value): void
     {
-        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new CustomVariableHeader($name, $value));
 
@@ -247,7 +247,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testEmailCategory($value): void
     {
-        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new CategoryHeader($value));
 
@@ -261,7 +261,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
 
     public function testInvalidCountOfEmailCategory(): void
     {
-        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new CategoryHeader('category 1'))
             ->add(new CategoryHeader('category 2'))
@@ -283,7 +283,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testTemplateUuid($value): void
     {
-        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new TemplateUuidHeader($value));
 
@@ -297,7 +297,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
 
     public function testInvalidCountOfTemplateUuid(): void
     {
-        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new TemplateUuidHeader('11111111-0000-0000-0000-8493da283a69'))
             ->add(new TemplateUuidHeader('22222222-0000-0000-0000-8493da283a69'))
@@ -319,7 +319,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testTemplateVariables($name, $value): void
     {
-        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new TemplateVariableHeader($name, $value));
 

--- a/tests/Api/AbstractEmailsTest.php
+++ b/tests/Api/AbstractEmailsTest.php
@@ -41,7 +41,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
         ];
 
         $email = new Email();
-        $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+        $email->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'))
             ->replyTo(new Address('reply@example.com'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
             ->priority(Email::PRIORITY_HIGH)
@@ -59,7 +59,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with($this->getHost() . '/api/send', [], [
                 'from' => [
-                    'email' => 'foo@example.com',
+                    'email' => 'from.adress.email@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [[
@@ -105,7 +105,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
         );
 
         $email = new Email();
-        $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+        $email->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'))
             ->text('Some text')
             ->html('<p>Some text</p>')
         ;
@@ -117,7 +117,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with($this->getHost() . '/api/send', [], [
                 'from' => [
-                    'email' => 'foo@example.com',
+                    'email' => 'from.adress.email@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [],
@@ -142,7 +142,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
         ];
 
         $email = (new Email())
-            ->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+            ->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
         ;
 
@@ -160,7 +160,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with($this->getHost() . '/api/send', [], [
                 'from' => [
-                    'email' => 'foo@example.com',
+                    'email' => 'from.adress.email@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [[
@@ -190,7 +190,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
     public function testAttachments(): void
     {
         $email = (new Email())
-            ->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+            ->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'))
             ->attach('fake_body', 'fakeFile.jpg', 'image/jpg')
         ;
 
@@ -212,7 +212,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testHeaders($name, $value): void
     {
-        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()->addTextHeader($name, $value);
 
         $method = new \ReflectionMethod(Emails::class, 'getPayload');
@@ -229,7 +229,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testCustomVariables($name, $value): void
     {
-        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new CustomVariableHeader($name, $value));
 
@@ -247,7 +247,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testEmailCategory($value): void
     {
-        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new CategoryHeader($value));
 
@@ -261,7 +261,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
 
     public function testInvalidCountOfEmailCategory(): void
     {
-        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new CategoryHeader('category 1'))
             ->add(new CategoryHeader('category 2'))
@@ -283,7 +283,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testTemplateUuid($value): void
     {
-        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new TemplateUuidHeader($value));
 
@@ -297,7 +297,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
 
     public function testInvalidCountOfTemplateUuid(): void
     {
-        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new TemplateUuidHeader('11111111-0000-0000-0000-8493da283a69'))
             ->add(new TemplateUuidHeader('22222222-0000-0000-0000-8493da283a69'))
@@ -319,7 +319,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testTemplateVariables($name, $value): void
     {
-        $email = (new Email())->from(new Address('foo@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new TemplateVariableHeader($name, $value));
 

--- a/tests/Api/AbstractEmailsTest.php
+++ b/tests/Api/AbstractEmailsTest.php
@@ -41,7 +41,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
         ];
 
         $email = new Email();
-        $email->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'))
+        $email->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'))
             ->replyTo(new Address('reply@example.com'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
             ->priority(Email::PRIORITY_HIGH)
@@ -59,7 +59,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with($this->getHost() . '/api/send', [], [
                 'from' => [
-                    'email' => 'from.adress.email@example.com',
+                    'email' => 'phpnuit@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [[
@@ -105,7 +105,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
         );
 
         $email = new Email();
-        $email->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'))
+        $email->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'))
             ->text('Some text')
             ->html('<p>Some text</p>')
         ;
@@ -117,7 +117,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with($this->getHost() . '/api/send', [], [
                 'from' => [
-                    'email' => 'from.adress.email@example.com',
+                    'email' => 'phpnuit@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [],
@@ -142,7 +142,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
         ];
 
         $email = (new Email())
-            ->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'))
+            ->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
         ;
 
@@ -160,7 +160,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with($this->getHost() . '/api/send', [], [
                 'from' => [
-                    'email' => 'from.adress.email@example.com',
+                    'email' => 'phpnuit@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [[
@@ -190,7 +190,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
     public function testAttachments(): void
     {
         $email = (new Email())
-            ->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'))
+            ->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'))
             ->attach('fake_body', 'fakeFile.jpg', 'image/jpg')
         ;
 
@@ -212,7 +212,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testHeaders($name, $value): void
     {
-        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()->addTextHeader($name, $value);
 
         $method = new \ReflectionMethod(Emails::class, 'getPayload');
@@ -229,7 +229,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testCustomVariables($name, $value): void
     {
-        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new CustomVariableHeader($name, $value));
 
@@ -247,7 +247,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testEmailCategory($value): void
     {
-        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new CategoryHeader($value));
 
@@ -261,7 +261,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
 
     public function testInvalidCountOfEmailCategory(): void
     {
-        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new CategoryHeader('category 1'))
             ->add(new CategoryHeader('category 2'))
@@ -283,7 +283,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testTemplateUuid($value): void
     {
-        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new TemplateUuidHeader($value));
 
@@ -297,7 +297,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
 
     public function testInvalidCountOfTemplateUuid(): void
     {
-        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new TemplateUuidHeader('11111111-0000-0000-0000-8493da283a69'))
             ->add(new TemplateUuidHeader('22222222-0000-0000-0000-8493da283a69'))
@@ -319,7 +319,7 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
      */
     public function testTemplateVariables($name, $value): void
     {
-        $email = (new Email())->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'));
+        $email = (new Email())->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'));
         $email->getHeaders()
             ->add(new TemplateVariableHeader($name, $value));
 

--- a/tests/Api/General/UserTest.php
+++ b/tests/Api/General/UserTest.php
@@ -109,7 +109,7 @@ class UserTest extends MailtrapTestCase
         $this->user->getList(self::FAKE_ACCOUNT_ID);
     }
 
-    public function testValidRemove()
+    public function testValidRemove(): void
     {
         $this->user->expects($this->once())
             ->method('httpDelete')

--- a/tests/Api/Sandbox/EmailsTest.php
+++ b/tests/Api/Sandbox/EmailsTest.php
@@ -55,7 +55,7 @@ final class EmailsTest extends MailtrapTestCase
         ];
 
         $email = new Email();
-        $email->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'))
+        $email->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'))
             ->replyTo(new Address('reply@example.com'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
             ->priority(Email::PRIORITY_HIGH)
@@ -72,7 +72,7 @@ final class EmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with(AbstractApi::SENDMAIL_SANDBOX_HOST . '/api/send/' . $inboxId, [], [
                 'from' => [
-                    'email' => 'from.adress.email@example.com',
+                    'email' => 'phpnuit@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [[
@@ -113,7 +113,7 @@ final class EmailsTest extends MailtrapTestCase
         ];
 
         $email = (new Email())
-            ->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'))
+            ->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
         ;
 
@@ -131,7 +131,7 @@ final class EmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with(AbstractApi::SENDMAIL_SANDBOX_HOST . '/api/send/' . $inboxId, [], [
                 'from' => [
-                    'email' => 'from.adress.email@example.com',
+                    'email' => 'phpnuit@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [[

--- a/tests/Api/Sandbox/EmailsTest.php
+++ b/tests/Api/Sandbox/EmailsTest.php
@@ -55,7 +55,7 @@ final class EmailsTest extends MailtrapTestCase
         ];
 
         $email = new Email();
-        $email->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'))
+        $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
             ->replyTo(new Address('reply@example.com'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
             ->priority(Email::PRIORITY_HIGH)
@@ -72,7 +72,7 @@ final class EmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with(AbstractApi::SENDMAIL_SANDBOX_HOST . '/api/send/' . $inboxId, [], [
                 'from' => [
-                    'email' => 'phpnuit@example.com',
+                    'email' => 'foo@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [[
@@ -113,7 +113,7 @@ final class EmailsTest extends MailtrapTestCase
         ];
 
         $email = (new Email())
-            ->from(new Address('phpnuit@example.com', 'Ms. Foo Bar'))
+            ->from(new Address('foo@example.com', 'Ms. Foo Bar'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
         ;
 
@@ -131,7 +131,7 @@ final class EmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with(AbstractApi::SENDMAIL_SANDBOX_HOST . '/api/send/' . $inboxId, [], [
                 'from' => [
-                    'email' => 'phpnuit@example.com',
+                    'email' => 'foo@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [[

--- a/tests/Api/Sandbox/EmailsTest.php
+++ b/tests/Api/Sandbox/EmailsTest.php
@@ -55,7 +55,7 @@ final class EmailsTest extends MailtrapTestCase
         ];
 
         $email = new Email();
-        $email->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+        $email->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'))
             ->replyTo(new Address('reply@example.com'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
             ->priority(Email::PRIORITY_HIGH)
@@ -72,7 +72,7 @@ final class EmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with(AbstractApi::SENDMAIL_SANDBOX_HOST . '/api/send/' . $inboxId, [], [
                 'from' => [
-                    'email' => 'foo@example.com',
+                    'email' => 'from.adress.email@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [[
@@ -113,7 +113,7 @@ final class EmailsTest extends MailtrapTestCase
         ];
 
         $email = (new Email())
-            ->from(new Address('foo@example.com', 'Ms. Foo Bar'))
+            ->from(new Address('from.adress.email@example.com', 'Ms. Foo Bar'))
             ->to(new Address('bar@example.com', 'Mr. Recipient'))
         ;
 
@@ -131,7 +131,7 @@ final class EmailsTest extends MailtrapTestCase
             ->method('httpPost')
             ->with(AbstractApi::SENDMAIL_SANDBOX_HOST . '/api/send/' . $inboxId, [], [
                 'from' => [
-                    'email' => 'foo@example.com',
+                    'email' => 'from.adress.email@example.com',
                     'name' => 'Ms. Foo Bar',
                 ],
                 'to' => [[

--- a/tests/Bridge/Transport/TransportFactoryTestCase.php
+++ b/tests/Bridge/Transport/TransportFactoryTestCase.php
@@ -43,7 +43,7 @@ abstract class TransportFactoryTestCase extends MailtrapTestCase
     /**
      * @dataProvider supportsProvider
      */
-    public function testSupports(Dsn $dsn, bool $supports)
+    public function testSupports(Dsn $dsn, bool $supports): void
     {
         $factory = $this->getFactory();
 
@@ -53,7 +53,7 @@ abstract class TransportFactoryTestCase extends MailtrapTestCase
     /**
      * @dataProvider createProvider
      */
-    public function testCreate(Dsn $dsn, TransportInterface $transport)
+    public function testCreate(Dsn $dsn, TransportInterface $transport): void
     {
         $factory = $this->getFactory();
 
@@ -66,7 +66,7 @@ abstract class TransportFactoryTestCase extends MailtrapTestCase
     /**
      * @dataProvider unsupportedSchemeProvider
      */
-    public function testUnsupportedSchemeException(Dsn $dsn, string $message = null)
+    public function testUnsupportedSchemeException(Dsn $dsn, string $message = null): void
     {
         $factory = $this->getFactory();
 
@@ -81,7 +81,7 @@ abstract class TransportFactoryTestCase extends MailtrapTestCase
     /**
      * @dataProvider incompleteDsnProvider
      */
-    public function testIncompleteDsnException(Dsn $dsn)
+    public function testIncompleteDsnException(Dsn $dsn): void
     {
         $factory = $this->getFactory();
 

--- a/tests/MailtrapTestCase.php
+++ b/tests/MailtrapTestCase.php
@@ -6,7 +6,6 @@ namespace Mailtrap\Tests;
 
 use Mailtrap\ConfigInterface;
 use Mailtrap\HttpClient\HttpClientBuilderInterface;
-use Mailtrap\MailtrapClientInterface;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Client\ClientInterface;
 


### PR DESCRIPTION
## Motivation
TODO 

## Changes

- PHP 7.4 support removed (only 2% customers are using this version)
- - They can still use the previous version 1.*, which supports PHP 7.4.
- improve codebase to support PHP 8.0 features


## How to test
