### PR TITLE
Issue-28 > support more types in template_variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.1] - 2024-08-16
+
+- Support mixed types in template_variables (array, string, int, float, bool)
+
 ## [2.0.0] - 2024-06-12
 - [BC BREAK] PHP 7.4 will no longer be supported (PHP 8.0+).
 - [BC BREAK] Rebuild `Emails` layers to use the `inboxId` at the client level ([examples](examples/testing/emails.php))

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -122,7 +122,7 @@ UPGRADE FROM 1.x to 2.0
           'user_name' => 'Jon Bush',
           'next_step_link' => 'https://mailtrap.io/',
           'get_started_link' => 'https://mailtrap.io/',
-          'onboarding_video_link' => 'some_video_link',
+          'onboarding_video_link' => 'some_video_link'
       ])
   ;
   ```

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -122,7 +122,7 @@ UPGRADE FROM 1.x to 2.0
           'user_name' => 'Jon Bush',
           'next_step_link' => 'https://mailtrap.io/',
           'get_started_link' => 'https://mailtrap.io/',
-          'onboarding_video_link' => 'some_video_link'
+          'onboarding_video_link' => 'some_video_link',
       ])
   ;
   ```

--- a/examples/sending/emails.php
+++ b/examples/sending/emails.php
@@ -90,7 +90,23 @@ try {
             'user_name' => 'Jon Bush',
             'next_step_link' => 'https://mailtrap.io/',
             'get_started_link' => 'https://mailtrap.io/',
-            'onboarding_video_link' => 'some_video_link'
+            'onboarding_video_link' => 'some_video_link',
+            'company' => [
+                'name' => 'Best Company',
+                'address' => 'Its Address',
+            ],
+            'products' => [
+                [
+                    'name' => 'Product 1',
+                    'price' => 100,
+                ],
+                [
+                    'name' => 'Product 2',
+                    'price' => 200,
+                ],
+            ],
+            'isBool' => true,
+            'int' => 123
         ])
     ;
 
@@ -184,7 +200,23 @@ try {
             'user_name' => 'Jon Bush',
             'next_step_link' => 'https://mailtrap.io/',
             'get_started_link' => 'https://mailtrap.io/',
-            'onboarding_video_link' => 'some_video_link'
+            'onboarding_video_link' => 'some_video_link',
+            'company' => [
+                'name' => 'Best Company',
+                'address' => 'Its Address',
+            ],
+            'products' => [
+                [
+                    'name' => 'Product 1',
+                    'price' => 100,
+                ],
+                [
+                    'name' => 'Product 2',
+                    'price' => 200,
+                ],
+            ],
+            'isBool' => true,
+            'int' => 123
         ])
     ;
 

--- a/examples/testing/emails.php
+++ b/examples/testing/emails.php
@@ -95,7 +95,23 @@ try {
             'user_name' => 'Jon Bush',
             'next_step_link' => 'https://mailtrap.io/',
             'get_started_link' => 'https://mailtrap.io/',
-            'onboarding_video_link' => 'some_video_link'
+            'onboarding_video_link' => 'some_video_link',
+            'company' => [
+                'name' => 'Best Company',
+                'address' => 'Its Address',
+            ],
+            'products' => [
+                [
+                    'name' => 'Product 1',
+                    'price' => 100,
+                ],
+                [
+                    'name' => 'Product 2',
+                    'price' => 200,
+                ],
+            ],
+            'isBool' => true,
+            'int' => 123
         ])
     ;
 

--- a/src/EmailHeader/Template/TemplateVariableHeader.php
+++ b/src/EmailHeader/Template/TemplateVariableHeader.php
@@ -15,19 +15,16 @@ class TemplateVariableHeader extends AbstractHeader
 {
     public const VAR_NAME = 'template_variables';
 
-    private string $value;
+    private mixed $value;
 
-    public function __construct(string $name, string $value)
+    public function __construct(string $name, mixed $value)
     {
         parent::__construct($name);
 
         $this->setValue($value);
     }
 
-    /**
-     * @param string $body
-     */
-    public function setBody($body): void
+    public function setBody(mixed $body): void
     {
         $this->setValue($body);
     }
@@ -43,7 +40,7 @@ class TemplateVariableHeader extends AbstractHeader
     /**
      * Get the (unencoded) value of this header.
      */
-    public function getValue(): string
+    public function getValue(): mixed
     {
         return $this->value;
     }
@@ -51,7 +48,7 @@ class TemplateVariableHeader extends AbstractHeader
     /**
      * Set the (unencoded) value of this header.
      */
-    public function setValue(string $value): void
+    public function setValue(mixed $value): void
     {
         $this->value = $value;
     }
@@ -61,6 +58,9 @@ class TemplateVariableHeader extends AbstractHeader
      */
     public function getBodyAsString(): string
     {
-        return $this->encodeWords($this, $this->value);
+        return $this->encodeWords(
+            $this,
+            is_array($this->value) ? json_encode($this->value, JSON_THROW_ON_ERROR) : $this->value
+        );
     }
 }

--- a/src/EmailHeader/Template/TemplateVariableHeader.php
+++ b/src/EmailHeader/Template/TemplateVariableHeader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Mailtrap\EmailHeader\Template;
 
+use Mailtrap\Exception\RuntimeException;
 use Symfony\Component\Mime\Header\AbstractHeader;
 
 /**
@@ -53,14 +54,8 @@ class TemplateVariableHeader extends AbstractHeader
         $this->value = $value;
     }
 
-    /**
-     * Get the value of this header prepared for rendering.
-     */
     public function getBodyAsString(): string
     {
-        return $this->encodeWords(
-            $this,
-            is_array($this->value) ? json_encode($this->value, JSON_THROW_ON_ERROR) : $this->value
-        );
+        throw new RuntimeException(__METHOD__ . ' method is not supported for this type of header');
     }
 }

--- a/src/EmailHeader/Template/TemplateVariableHeader.php
+++ b/src/EmailHeader/Template/TemplateVariableHeader.php
@@ -32,7 +32,7 @@ class TemplateVariableHeader extends AbstractHeader
     /**
      * @psalm-suppress MethodSignatureMismatch
      */
-    public function getBody(): string
+    public function getBody(): mixed
     {
         return $this->getValue();
     }

--- a/src/Mime/MailtrapEmail.php
+++ b/src/Mime/MailtrapEmail.php
@@ -29,7 +29,7 @@ class MailtrapEmail extends Email
         return $this;
     }
 
-    public function templateVariable(string $name, string $value): self
+    public function templateVariable(string $name, mixed $value): self
     {
         $this->getHeaders()->add(new TemplateVariableHeader($name, $value));
 

--- a/tests/Api/AbstractEmailsTest.php
+++ b/tests/Api/AbstractEmailsTest.php
@@ -154,6 +154,22 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
             ->add(new TemplateVariableHeader('next_step_link', 'https://mailtrap.io/'))
             ->add(new TemplateVariableHeader('get_started_link', 'https://mailtrap.io/'))
             ->add(new TemplateVariableHeader('onboarding_video_link', 'some_video_link'))
+            ->add(new TemplateVariableHeader('company', [
+                'name' => 'Best Company',
+                'address' => 'Its Address',
+            ]))
+            ->add(new TemplateVariableHeader('products', [
+                [
+                    'name' => 'Product 1',
+                    'price' => 100,
+                ],
+                [
+                    'name' => 'Product 2',
+                    'price' => 200,
+                ],
+            ]))
+            ->add(new TemplateVariableHeader('isBool', true))
+            ->add(new TemplateVariableHeader('int', 123))
         ;
 
         $this->email
@@ -175,6 +191,22 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
                     'next_step_link' => 'https://mailtrap.io/',
                     'get_started_link' => 'https://mailtrap.io/',
                     'onboarding_video_link' => 'some_video_link',
+                    'company' => [
+                        'name' => 'Best Company',
+                        'address' => 'Its Address',
+                    ],
+                    'products' => [
+                        [
+                            'name' => 'Product 1',
+                            'price' => 100,
+                        ],
+                        [
+                            'name' => 'Product 2',
+                            'price' => 200,
+                        ],
+                    ],
+                    'isBool' => true,
+                    'int' => 123,
                 ]
             ])
             ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedData)));
@@ -206,7 +238,23 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
                 'unicode_user_name' => 'Subašić',
                 'next_step_link' => 'https://mailtrap.io/',
                 'get_started_link' => 'https://mailtrap.io/',
-                'onboarding_video_link' => 'some_video_link'
+                'onboarding_video_link' => 'some_video_link',
+                'company' => [
+                    'name' => 'Best Company',
+                    'address' => 'Its Address',
+                ],
+                'products' => [
+                    [
+                        'name' => 'Product 1',
+                        'price' => 100,
+                    ],
+                    [
+                        'name' => 'Product 2',
+                        'price' => 200,
+                    ],
+                ],
+                'isBool' => true,
+                'int' => 123,
             ])
         ;
 
@@ -229,6 +277,22 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
                     'next_step_link' => 'https://mailtrap.io/',
                     'get_started_link' => 'https://mailtrap.io/',
                     'onboarding_video_link' => 'some_video_link',
+                    'company' => [
+                        'name' => 'Best Company',
+                        'address' => 'Its Address',
+                    ],
+                    'products' => [
+                        [
+                            'name' => 'Product 1',
+                            'price' => 100,
+                        ],
+                        [
+                            'name' => 'Product 2',
+                            'price' => 200,
+                        ],
+                    ],
+                    'isBool' => true,
+                    'int' => 123,
                 ]
             ])
             ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedData)));
@@ -533,6 +597,22 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
             ['user_name', 'Jon Bush'],
             ['next_step_link', 'https://mailtrap.io/'],
             ['onboarding_video_link', 'some_video_link'],
+            ['company', [
+                'name' => 'Best Company',
+                'address' => 'Its Address',
+            ]],
+            ['products', [
+                [
+                    'name' => 'Product 1',
+                    'price' => 100,
+                ],
+                [
+                    'name' => 'Product 2',
+                    'price' => 200,
+                ],
+            ]],
+            ['isBool', true],
+            ['int', 123],
         ];
     }
 

--- a/tests/Api/Sandbox/EmailsTest.php
+++ b/tests/Api/Sandbox/EmailsTest.php
@@ -123,6 +123,22 @@ final class EmailsTest extends MailtrapTestCase
             ->add(new TemplateVariableHeader('next_step_link', 'https://mailtrap.io/'))
             ->add(new TemplateVariableHeader('get_started_link', 'https://mailtrap.io/'))
             ->add(new TemplateVariableHeader('onboarding_video_link', 'some_video_link'))
+            ->add(new TemplateVariableHeader('company', [
+                'name' => 'Best Company',
+                'address' => 'Its Address',
+            ]))
+            ->add(new TemplateVariableHeader('products', [
+                [
+                    'name' => 'Product 1',
+                    'price' => 100,
+                ],
+                [
+                    'name' => 'Product 2',
+                    'price' => 200,
+                ],
+            ]))
+            ->add(new TemplateVariableHeader('isBool', true))
+            ->add(new TemplateVariableHeader('int', 123))
         ;
 
         $this->email
@@ -144,6 +160,22 @@ final class EmailsTest extends MailtrapTestCase
                     'next_step_link' => 'https://mailtrap.io/',
                     'get_started_link' => 'https://mailtrap.io/',
                     'onboarding_video_link' => 'some_video_link',
+                    'company' => [
+                        'name' => 'Best Company',
+                        'address' => 'Its Address',
+                    ],
+                    'products' => [
+                        [
+                            'name' => 'Product 1',
+                            'price' => 100,
+                        ],
+                        [
+                            'name' => 'Product 2',
+                            'price' => 200,
+                        ],
+                    ],
+                    'isBool' => true,
+                    'int' => 123,
                 ]
             ])
             ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedData)));
@@ -176,6 +208,22 @@ final class EmailsTest extends MailtrapTestCase
                 'next_step_link' => 'https://mailtrap.io/',
                 'get_started_link' => 'https://mailtrap.io/',
                 'onboarding_video_link' => 'some_video_link',
+                'company' => [
+                    'name' => 'Best Company',
+                    'address' => 'Its Address',
+                ],
+                'products' => [
+                    [
+                        'name' => 'Product 1',
+                        'price' => 100,
+                    ],
+                    [
+                        'name' => 'Product 2',
+                        'price' => 200,
+                    ],
+                ],
+                'isBool' => true,
+                'int' => 123,
             ])
         ;
 
@@ -198,6 +246,22 @@ final class EmailsTest extends MailtrapTestCase
                     'next_step_link' => 'https://mailtrap.io/',
                     'get_started_link' => 'https://mailtrap.io/',
                     'onboarding_video_link' => 'some_video_link',
+                    'company' => [
+                        'name' => 'Best Company',
+                        'address' => 'Its Address',
+                    ],
+                    'products' => [
+                        [
+                            'name' => 'Product 1',
+                            'price' => 100,
+                        ],
+                        [
+                            'name' => 'Product 2',
+                            'price' => 200,
+                        ],
+                    ],
+                    'isBool' => true,
+                    'int' => 123
                 ]
             ])
             ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedData)));


### PR DESCRIPTION
## Motivation

Issue - https://github.com/railsware/mailtrap-php/issues/28

## Changes

- Add support for mixed types for template_variables

## How to test

```bash
composer test
```
OR send a `template` email with all possible variables
```php
$email = (new MailtrapEmail())
            ->from(new Address('mailtrap_test@mailtrap.io', 'Mailtrap Test'))
            ->to(new Address('test@mailtrap.io', 'Jon'))
            ->templateUuid('bfa432fd-1111-111-111-8493da283a69')
            ->templateVariables([
                'user_name' => 'Jon Bush',
                'next_step_link' => 'https://mailtrap.io/',
                'get_started_link' => 'https://mailtrap.io/',
                'onboarding_video_link' => 'some_video_link',
                'company' => [
                    'name' => 'Best Company',
                    'address' => 'Its Address',
                ],
                'products' => [
                    [
                        'name' => 'Product 1',
                        'price' => 100,
                    ],
                    [
                        'name' => 'Product 2',
                        'price' => 200,
                    ],
                ],
                'isBool' => true,
                'int' => 123
            ])
        ;

        $response = MailtrapClient::initSendingEmails(
            apiKey: getenv('MAILTRAP_API_KEY')
        )->send($email);
```