### PR TITLE
Fix broken Unit tests after symfony/mailer update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [2.0.2] - 2024-10-04
+
+- Remove an expected message from the `testUnsupportedSchemeException` method ([reason](https://github.com/symfony/mailer/commit/a098a3fe7f42a30235b862162090900cbf787ff6))
+
+
 ## [2.0.1] - 2024-08-16
 
 - Support mixed types in template_variables (array, string, int, float, bool)

--- a/tests/Bridge/Transport/MailtrapTransportFactoryTest.php
+++ b/tests/Bridge/Transport/MailtrapTransportFactoryTest.php
@@ -131,8 +131,7 @@ class MailtrapTransportFactoryTest extends TransportFactoryTestCase
     public function unsupportedSchemeProvider(): iterable
     {
         yield [
-            new Dsn('mailtrap+foo', 'mailtrap', self::USER),
-            'The "mailtrap+foo" scheme is not supported; supported schemes for mailer "mailtrap" are: "mailtrap", "mailtrap+api".',
+            new Dsn('mailtrap+foo', 'mailtrap', self::USER)
         ];
     }
 


### PR DESCRIPTION
## Motivation

Broken Unit tests - https://github.com/railsware/mailtrap-php/actions/runs/11153547113/job/31001260601
Reason - https://github.com/symfony/mailer/commit/a098a3fe7f42a30235b862162090900cbf787ff6

## Changes

- Remove an expected message from the test (testUnsupportedSchemeException) and leave only exception class, because the message may vary for different PHP versions

## How to test

```
composer test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the changelog to reflect version 2.0.2, documenting the removal of an expected message in the testing framework.
- **Bug Fixes**
	- Simplified the output of the `unsupportedSchemeProvider` method by removing the accompanying error message from the test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->