### PR TITLE
Add more template examples in Laravel/Symfony docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.3] - 2024-11-01
+
+- Add more template examples in Laravel/Symfony docs
+
 ## [2.0.2] - 2024-10-04
 
 - Remove an expected message from the `testUnsupportedSchemeException` method ([reason](https://github.com/symfony/mailer/commit/a098a3fe7f42a30235b862162090900cbf787ff6))

--- a/src/Bridge/Laravel/README.md
+++ b/src/Bridge/Laravel/README.md
@@ -80,7 +80,7 @@ Firstly you need to generate `Mailable` class. More info [here](https://laravel.
 ```bash
 php artisan make:mail WelcomeMail
 ```
-After that you can configure you Email as you which. Below will be example.
+After that, you can configure your Email as you which. Below will be an example.
 ```php
 # app/Mail/WelcomeMail.php
 <?php
@@ -188,7 +188,7 @@ class WelcomeMail extends Mailable
     }
 }
 ```
-Email template
+Create email template `resources/views/mail/welcome-email.blade.php`
 ```php
 # resources/views/mail/welcome-email.blade.php
 
@@ -216,6 +216,7 @@ use Illuminate\Support\Facades\Mail;
 
 Artisan::command('send-welcome-mail', function () {
     Mail::to('testreceiver@gmail.com')->send(new WelcomeMail("Jon"));
+    
     // Also, you can use specific mailer if your default mailer is not "mailtrap" but you want to use it for welcome mails
     // Mail::mailer('mailtrap')->to('testreceiver@gmail.com')->send(new WelcomeMail("Jon"));
 })->purpose('Send welcome mail');
@@ -224,6 +225,63 @@ Artisan::command('send-welcome-mail', function () {
 After that just call this CLI command, and it will send your email
 ```bash
 php artisan send-welcome-mail
+```
+
+### Send Template Email
+To send 'Template Email', you should use the native library and its methods,
+as mail transport validation does not allow you to send emails without ‘html’ or ‘text’.
+
+Add CLI command
+```php
+# app/routes/console.php
+<?php
+
+use Illuminate\Support\Facades\Artisan;
+use Mailtrap\MailtrapClient;
+use Mailtrap\Mime\MailtrapEmail;
+use Symfony\Component\Mime\Address;
+
+Artisan::command('send-template-mail', function () {
+    $email = (new MailtrapEmail())
+        ->from(new Address('example@YOUR-DOMAIN-HERE.com', 'Mailtrap Test')) // <--- you should use your domain here that you installed in the mailtrap.io admin area (otherwise you will get 401)
+        ->replyTo(new Address('reply@YOUR-DOMAIN-HERE.com'))
+        ->to(new Address('example@gmail.com', 'Jon'))
+        // when using a template, you should not set a subject, text, HTML, category
+        // otherwise there will be a validation error from the API side
+        ->templateUuid('bfa432fd-0000-0000-0000-8493da283a69')
+        ->templateVariables([
+            'user_name' => 'Jon Bush',
+            'next_step_link' => 'https://mailtrap.io/',
+            'get_started_link' => 'https://mailtrap.io/',
+            'onboarding_video_link' => 'some_video_link',
+            'company' => [
+                'name' => 'Best Company',
+                'address' => 'Its Address',
+            ],
+            'products' => [
+                [
+                    'name' => 'Product 1',
+                    'price' => 100,
+                ],
+                [
+                    'name' => 'Product 2',
+                    'price' => 200,
+                ],
+            ],
+            'isBool' => true,
+            'int' => 123
+        ])
+    ;
+
+    MailtrapClient::initSendingEmails(
+        apiKey: env('MAILTRAP_API_KEY') // your API token from here https://mailtrap.io/api-tokens
+    )->send($email);
+})->purpose('Send Template Mail');
+```
+
+After that just call this CLI command, and it will send your template email
+```bash
+php artisan send-template-mail
 ```
 
 ## Compatibility

--- a/src/Bridge/Laravel/README.md
+++ b/src/Bridge/Laravel/README.md
@@ -80,7 +80,7 @@ Firstly you need to generate `Mailable` class. More info [here](https://laravel.
 ```bash
 php artisan make:mail WelcomeMail
 ```
-After that, you can configure your Email as you which. Below will be an example.
+After that, you can configure your Email as you wish. Below will be an example.
 ```php
 # app/Mail/WelcomeMail.php
 <?php
@@ -228,7 +228,7 @@ php artisan send-welcome-mail
 ```
 
 ### Send Template Email
-To send 'Template Email', you should use the native library and its methods,
+To send using Mailtrap Email Template, you should use the native library and its methods,
 as mail transport validation does not allow you to send emails without ‘html’ or ‘text’.
 
 Add CLI command

--- a/src/Bridge/Symfony/README.md
+++ b/src/Bridge/Symfony/README.md
@@ -58,10 +58,12 @@ php bin/console mailer:test to@example.com
 ```php
 <?php
 
+use Mailtrap\MailtrapClient;
 use Mailtrap\Mime\MailtrapEmail;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -76,11 +78,11 @@ final class SomeController extends AbstractController
     }
 
     /**
-     * @Route(name="send-test-email", path="/test", methods={"GET"})
+     * @Route(name="send-email", path="/send-email", methods={"GET"})
      *
      * @return JsonResponse
      */
-    public function sendTestEmail(): JsonResponse
+    public function sendEmail(): JsonResponse
     {
         $message = (new MailtrapEmail())
             ->from('from@xample.com')
@@ -101,6 +103,54 @@ final class SomeController extends AbstractController
         $response = $this->transport->send($message);
 
         return JsonResponse::create(['messageId' => $response->getMessageId()]);
+    }
+    
+    /**
+     * WARNING! To send ‘Template Email, you should use the native library and its methods,
+     * as mail transport validation does not allow you to send emails without ‘html’ or ‘text’
+     *
+     * @Route(name="send-template-email", path="/send-template-email", methods={"GET"})
+     *
+     * @return JsonResponse
+     */
+    public function sendTemplateEmail(): JsonResponse
+    {
+        $email = (new MailtrapEmail())
+            ->from(new Address('example@YOUR-DOMAIN-HERE.com', 'Mailtrap Test')) // <--- you should use your domain here that you installed in the mailtrap.io admin area (otherwise you will get 401)
+            ->replyTo(new Address('reply@YOUR-DOMAIN-HERE.com'))
+            ->to(new Address('example@gmail.com', 'Jon'))
+            // when using a template, you should not set a subject, text, HTML, category
+            // otherwise there will be a validation error from the API side
+            ->templateUuid('bfa432fd-0000-0000-0000-8493da283a69')
+            ->templateVariables([
+                'user_name' => 'Jon Bush',
+                'next_step_link' => 'https://mailtrap.io/',
+                'get_started_link' => 'https://mailtrap.io/',
+                'onboarding_video_link' => 'some_video_link',
+                'company' => [
+                    'name' => 'Best Company',
+                    'address' => 'Its Address',
+                ],
+                'products' => [
+                    [
+                        'name' => 'Product 1',
+                        'price' => 100,
+                    ],
+                    [
+                        'name' => 'Product 2',
+                        'price' => 200,
+                    ],
+                ],
+                'isBool' => true,
+                'int' => 123
+            ])
+        ;
+
+        $response = MailtrapClient::initSendingEmails(
+            apiKey: env('MAILTRAP_API_KEY') // your API token from here https://mailtrap.io/api-tokens
+        )->send($email);
+
+        return JsonResponse::create(ResponseHelper::toArray($response));
     }
 }
 ```

--- a/src/Bridge/Symfony/README.md
+++ b/src/Bridge/Symfony/README.md
@@ -107,7 +107,7 @@ final class SomeController extends AbstractController
     }
     
     /**
-     * WARNING! To send ‘Template Email, you should use the native library and its methods,
+     * WARNING! To send using Mailtrap Email Template, you should use the native library and its methods,
      * as mail transport validation does not allow you to send emails without ‘html’ or ‘text’
      *
      * @Route(name="send-template-email", path="/send-template-email", methods={"GET"})

--- a/src/Bridge/Symfony/README.md
+++ b/src/Bridge/Symfony/README.md
@@ -60,6 +60,7 @@ php bin/console mailer:test to@example.com
 
 use Mailtrap\MailtrapClient;
 use Mailtrap\Mime\MailtrapEmail;
+use Mailtrap\Helper\ResponseHelper;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Mailer\Transport\TransportInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;


### PR DESCRIPTION
## Motivation
Due to the fact that sending template email has its own specifics, users will not understand how to send it, if do not specify HTML and Text, which are mandatory in the mailer plugin which are using both frameworks.

## Changes

- Add examples into Symfony and Laravel docs

## How to test

No code changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new CLI command `send-template-mail` for sending emails using predefined templates in Laravel.
  - Introduced a method `sendTemplateEmail` for sending template emails in Symfony.

- **Documentation**
  - Enhanced the Laravel README with clearer instructions on sending emails and updated compatibility details.
  - Updated the Symfony README with revised method names and improved instructions for sending emails, including template usage.

- **Chores**
  - Added a new entry in the CHANGELOG for version `2.0.3`, summarizing recent updates and changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->