### PR TITLE
Add name prefix into custom EmailHeaders to avoid conflicts with reserved names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.4] - 2025-01-22
+
+- Add name prefix into custom EmailHeaders to avoid conflicts with reserved names Symfony\Component\Mime\Header\Headers::HEADER_CLASS_MAP
+
 ## [2.0.3] - 2024-11-01
 
 - Add more template examples in Laravel/Symfony docs

--- a/src/Api/AbstractEmails.php
+++ b/src/Api/AbstractEmails.php
@@ -58,10 +58,10 @@ abstract class AbstractEmails extends AbstractApi implements EmailsSendApiInterf
 
             switch(true) {
                 case $header instanceof CustomVariableHeader:
-                    $payload[CustomVariableHeader::VAR_NAME][$header->getName()] = $header->getValue();
+                    $payload[CustomVariableHeader::VAR_NAME][$header->getNameWithoutPrefix()] = $header->getValue();
                     break;
                 case $header instanceof TemplateVariableHeader:
-                    $payload[TemplateVariableHeader::VAR_NAME][$header->getName()] = $header->getValue();
+                    $payload[TemplateVariableHeader::VAR_NAME][$header->getNameWithoutPrefix()] = $header->getValue();
                     break;
                 case $header instanceof CategoryHeader:
                     if (!empty($payload[CategoryHeader::VAR_NAME])) {

--- a/src/EmailHeader/CustomHeaderInterface.php
+++ b/src/EmailHeader/CustomHeaderInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\EmailHeader;
+
+interface CustomHeaderInterface
+{
+    public function getNameWithoutPrefix(): string;
+}

--- a/src/EmailHeader/CustomVariableHeader.php
+++ b/src/EmailHeader/CustomVariableHeader.php
@@ -11,15 +11,17 @@ use Symfony\Component\Mime\Header\AbstractHeader;
  *
  * Class CustomVariableHeader
  */
-class CustomVariableHeader extends AbstractHeader
+class CustomVariableHeader extends AbstractHeader implements CustomHeaderInterface
 {
     public const VAR_NAME = 'custom_variables';
+    public const NAME_PREFIX = 'custom_variables_prefix_';
 
     private string $value;
 
     public function __construct(string $name, string $value)
     {
-        parent::__construct($name);
+        // add prefix to avoid conflicts with reserved header names Symfony\Component\Mime\Header\Headers::HEADER_CLASS_MAP
+        parent::__construct(self::NAME_PREFIX . $name);
 
         $this->setValue($value);
     }
@@ -54,6 +56,11 @@ class CustomVariableHeader extends AbstractHeader
     public function setValue(string $value): void
     {
         $this->value = $value;
+    }
+
+    public function getNameWithoutPrefix(): string
+    {
+        return substr($this->getName(), strlen(self::NAME_PREFIX));
     }
 
     /**

--- a/src/EmailHeader/Template/TemplateVariableHeader.php
+++ b/src/EmailHeader/Template/TemplateVariableHeader.php
@@ -4,23 +4,26 @@ declare(strict_types=1);
 
 namespace Mailtrap\EmailHeader\Template;
 
+use Mailtrap\EmailHeader\CustomHeaderInterface;
 use Mailtrap\Exception\RuntimeException;
 use Symfony\Component\Mime\Header\AbstractHeader;
 
 /**
  * MIME Header for Template UUID
  *
- * Class CustomVariableHeader
+ * Class TemplateVariableHeader
  */
-class TemplateVariableHeader extends AbstractHeader
+class TemplateVariableHeader extends AbstractHeader implements CustomHeaderInterface
 {
     public const VAR_NAME = 'template_variables';
+    public const NAME_PREFIX = 'template_variables_prefix_';
 
     private mixed $value;
 
     public function __construct(string $name, mixed $value)
     {
-        parent::__construct($name);
+        // add prefix to avoid conflicts with reserved header names Symfony\Component\Mime\Header\Headers::HEADER_CLASS_MAP
+        parent::__construct(self::NAME_PREFIX . $name);
 
         $this->setValue($value);
     }
@@ -52,6 +55,11 @@ class TemplateVariableHeader extends AbstractHeader
     public function setValue(mixed $value): void
     {
         $this->value = $value;
+    }
+
+    public function getNameWithoutPrefix(): string
+    {
+        return substr($this->getName(), strlen(self::NAME_PREFIX));
     }
 
     public function getBodyAsString(): string

--- a/tests/Api/AbstractEmailsTest.php
+++ b/tests/Api/AbstractEmailsTest.php
@@ -572,6 +572,17 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
         return [
             ['user_id', '45982'],
             ['batch_id', 'PSJ-12'],
+            ['date', '2025'],
+            ['from', 'Some name'],
+            ['sender', 'Sender info'],
+            ['reply-to', 'Reply to info'],
+            ['to', 'To info'],
+            ['cc', 'Cc info'],
+            ['bcc', 'Bcc info'],
+            ['message-id', 'Message ID info'],
+            ['in-reply-to', 'In reply to info'],
+            ['references', 'References info'],
+            ['return-path', 'Return path info'],
         ];
     }
 
@@ -613,6 +624,17 @@ abstract class AbstractEmailsTest extends MailtrapTestCase
             ]],
             ['isBool', true],
             ['int', 123],
+            ['date', '2025'],
+            ['from', 'Some name'],
+            ['sender', 'Sender info'],
+            ['reply-to', 'Reply to info'],
+            ['to', 'To info'],
+            ['cc', 'Cc info'],
+            ['bcc', 'Bcc info'],
+            ['message-id', 'Message ID info'],
+            ['in-reply-to', 'In reply to info'],
+            ['references', 'References info'],
+            ['return-path', 'Return path info'],
         ];
     }
 


### PR DESCRIPTION
## Motivation

Issue - https://github.com/railsware/mailtrap-php/issues/34
> Conflict with reserved mime header names

## Changes

- Add name prefix into custom EmailHeaders to avoid conflicts with reserved names Symfony\Component\Mime\Header\Headers::HEADER_CLASS_MAP

p.s. prefix is added only at the time of request generation and is not passed to MailTrap

## How to test
```bash
composer test
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes for Version 2.0.4

- **New Features**
  - Introduced a new `CustomHeaderInterface` to manage email header names
  - Added name prefix mechanism for custom email headers to prevent naming conflicts

- **Improvements**
  - Enhanced email header processing to handle reserved names more effectively
  - Updated custom and template variable header implementations

- **Bug Fixes**
  - Resolved potential naming conflicts with Symfony's reserved header names

- **Tests**
  - Expanded test coverage for custom and template variable scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->