### PR TITLE
Add Contact API functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.1.0] - 2025-05-27
+- Add Contacts API functionality
+
 ## [3.0.0] - 2025-05-15
 
 - [BC BREAK] Change Symfony&Laravel integration naming from `mailtrap+api` to `mailtrap+sdk` ([reason](https://symfony.com/packages/MailtrapMailer))

--- a/examples/general/contacts.php
+++ b/examples/general/contacts.php
@@ -1,0 +1,104 @@
+<?php
+
+use Mailtrap\Config;
+use Mailtrap\DTO\Request\Contact\CreateContact;
+use Mailtrap\DTO\Request\Contact\UpdateContact;
+use Mailtrap\Helper\ResponseHelper;
+use Mailtrap\MailtrapGeneralClient;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$accountId = getenv('MAILTRAP_ACCOUNT_ID');
+$config = new Config(getenv('MAILTRAP_API_KEY')); #your API token from here https://mailtrap.io/api-tokens
+$contacts = (new MailtrapGeneralClient($config))->contacts($accountId);
+
+/**
+ * Get all Contact Lists.
+ *
+ * GET https://mailtrap.io/api/accounts/{account_id}/contacts/lists
+ */
+try {
+    $response = $contacts->getAllContactLists();
+
+    // print the response body (array)
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
+}
+
+
+/**
+ * Create a new Contact
+ *
+ * POST https://mailtrap.io/api/accounts/{account_id}/contacts
+ */
+try {
+    $response = $contacts->createContact(
+        CreateContact::init(
+            'john.smith@example.com',
+            ['first_name' => 'John', 'last_name' => 'Smith'], // Fields
+            [1, 2] // List IDs to which the contact will be added
+        )
+    );
+
+    // print the response body (array)
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
+}
+
+
+/**
+ * Update contact by ID or Email.
+ *
+ * PATCH https://mailtrap.io/api/accounts/{account_id}/contacts/{id_or_email}
+ */
+try {
+    // Update contact by ID
+    $response = $contacts->updateContactById(
+        '019706a8-0000-0000-0000-4f26816b467a',
+        UpdateContact::init(
+            'john.smith@example.com',
+            ['first_name' => 'John', 'last_name' => 'Smith'], // Fields
+            [3], // List IDs to which the contact will be added
+            [1, 2], // List IDs from which the contact will be removed
+            true // Unsubscribe the contact
+        )
+    );
+
+    // OR update contact by email
+    $response = $contacts->updateContactByEmail(
+        'john.smith@example.com',
+        UpdateContact::init(
+            'john.smith@example.com',
+            ['first_name' => 'John', 'last_name' => 'Smith'], // Fields
+            [3], // List IDs to which the contact will be added
+            [1, 2], // List IDs from which the contact will be removed
+            true // Unsubscribe the contact
+        )
+    );
+
+    // print the response body (array)
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
+}
+
+
+/**
+ * Delete contact
+ *
+ * Delete https://mailtrap.io/api/accounts/{account_id}/contacts/{id_or_email}
+ */
+try {
+    // Delete contact by ID
+    $response = $contacts->deleteContactById('019706a8-0000-0000-0000-4f26816b467a');
+
+    // OR delete contact by email
+    $response = $contacts->deleteContactByEmail('john.smith@example.com');
+
+    // print the response body (array)
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
+}

--- a/src/Api/General/Contact.php
+++ b/src/Api/General/Contact.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\Api\General;
+
+use Mailtrap\Api\AbstractApi;
+use Mailtrap\ConfigInterface;
+use Mailtrap\DTO\Request\Contact\CreateContact;
+use Mailtrap\DTO\Request\Contact\UpdateContact;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class Contact
+ */
+class Contact extends AbstractApi implements GeneralInterface
+{
+    public function __construct(ConfigInterface $config, private int $accountId)
+    {
+        parent::__construct($config);
+    }
+
+    /**
+     * Get all Contact Lists.
+     *
+     * @return ResponseInterface
+     */
+    public function getAllContactLists(): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpGet($this->getBasePath() . '/lists')
+        );
+    }
+
+    /**
+     * Create a new Contact.
+     *
+     * @param CreateContact $contact
+     * @return ResponseInterface
+     */
+    public function createContact(CreateContact $contact): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpPost(path: $this->getBasePath(), body: ['contact' => $contact->toArray()])
+        );
+    }
+
+    /**
+     * Update an existing Contact by ID (UUID).
+     *
+     * @param string $contactId
+     * @param UpdateContact $contact
+     * @return ResponseInterface
+     */
+    public function updateContactById(string $contactId, UpdateContact $contact): ResponseInterface
+    {
+        return $this->updateContact($contactId, $contact);
+    }
+
+    /**
+     * Update an existing Contact by Email.
+     *
+     * @param string $email
+     * @param UpdateContact $contact
+     * @return ResponseInterface
+     */
+    public function updateContactByEmail(string $email, UpdateContact $contact): ResponseInterface
+    {
+        return $this->updateContact($email, $contact);
+    }
+
+    /**
+     * Delete a Contact by ID (UUID).
+     *
+     * @param string $contactId
+     * @return ResponseInterface
+     */
+    public function deleteContactById(string $contactId): ResponseInterface
+    {
+        return $this->deleteContact($contactId);
+    }
+
+    /**
+     * Delete a Contact by Email.
+     *
+     * @param string $email
+     * @return ResponseInterface
+     */
+    public function deleteContactByEmail(string $email): ResponseInterface
+    {
+        return $this->deleteContact($email);
+    }
+
+    public function getAccountId(): int
+    {
+        return $this->accountId;
+    }
+
+    /**
+     * Update an existing Contact.
+     *
+     * @param string $contactIdOrEmail
+     * @param UpdateContact $contact
+     * @return ResponseInterface
+     */
+    private function updateContact(string $contactIdOrEmail, UpdateContact $contact): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpPut(
+                path: $this->getBasePath() . '/' . $contactIdOrEmail,
+                body: ['contact' => $contact->toArray()]
+            )
+        );
+    }
+
+    /**
+     * Delete a Contact by ID or Email.
+     *
+     * @param string $idOrEmail
+     * @return ResponseInterface
+     */
+    private function deleteContact(string $idOrEmail): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpDelete($this->getBasePath() . '/' . $idOrEmail)
+        );
+    }
+
+    private function getBasePath(): string
+    {
+        return sprintf('%s/api/accounts/%s/contacts', $this->getHost(), $this->getAccountId());
+    }
+}

--- a/src/Api/General/Contact.php
+++ b/src/Api/General/Contact.php
@@ -107,7 +107,7 @@ class Contact extends AbstractApi implements GeneralInterface
     {
         return $this->handleResponse(
             $this->httpPut(
-                path: $this->getBasePath() . '/' . $contactIdOrEmail,
+                path: $this->getBasePath() . '/' . urlencode($contactIdOrEmail),
                 body: ['contact' => $contact->toArray()]
             )
         );
@@ -122,7 +122,7 @@ class Contact extends AbstractApi implements GeneralInterface
     private function deleteContact(string $idOrEmail): ResponseInterface
     {
         return $this->handleResponse(
-            $this->httpDelete($this->getBasePath() . '/' . $idOrEmail)
+            $this->httpDelete($this->getBasePath() . '/' . urlencode($idOrEmail))
         );
     }
 

--- a/src/DTO/Request/Contact/ContactInterface.php
+++ b/src/DTO/Request/Contact/ContactInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Mailtrap\DTO\Request\Contact;
+
+use Mailtrap\DTO\Request\RequestInterface;
+
+interface ContactInterface extends RequestInterface
+{
+    /**
+     * The email of the contact.
+     *
+     * @return string
+     */
+    public function getEmail(): string;
+
+    /**
+     * The fields of the contact.
+     *
+     * @return array
+     */
+    public function getFields(): array;
+}

--- a/src/DTO/Request/Contact/CreateContact.php
+++ b/src/DTO/Request/Contact/CreateContact.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\DTO\Request\Contact;
+
+/**
+ * Class CreateContact
+ */
+final class CreateContact implements ContactInterface
+{
+    public function __construct(
+        private string $email,
+        private array $fields = [],
+        private array $listIds = []
+    ) {
+    }
+
+    public static function init(string $email, array $fields = [], array $listIds = []): self
+    {
+        return new self($email, $fields, $listIds);
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    public function getListIds(): array
+    {
+        return $this->listIds;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'email' => $this->getEmail(),
+            'fields' => $this->getFields(),
+            'list_ids' => $this->getListIds(),
+        ];
+    }
+}

--- a/src/DTO/Request/Contact/UpdateContact.php
+++ b/src/DTO/Request/Contact/UpdateContact.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\DTO\Request\Contact;
+
+/**
+ * Class UpdateContact
+ */
+final class UpdateContact implements ContactInterface
+{
+    public function __construct(
+        private string $email,
+        private array $fields = [],
+        private array $listIdsIncluded = [],
+        private array $listIdsExcluded = [],
+        private ?bool $unsubscribed = null
+    ) {
+    }
+
+    public static function init(
+        string $email,
+        array $fields = [],
+        array $listIdsIncluded = [],
+        array $listIdsExcluded = [],
+        ?bool $unsubscribed = null
+    ): self {
+        return new self($email, $fields, $listIdsIncluded, $listIdsExcluded, $unsubscribed);
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    public function getListIdsIncluded(): array
+    {
+        return $this->listIdsIncluded;
+    }
+
+    public function getListIdsExcluded(): array
+    {
+        return $this->listIdsExcluded;
+    }
+
+    public function getUnsubscribed(): ?bool
+    {
+        return $this->unsubscribed;
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'email' => $this->getEmail(),
+            'fields' => $this->getFields(),
+            'list_ids_included' => $this->getListIdsIncluded(),
+            'list_ids_excluded' => $this->getListIdsExcluded(),
+            'unsubscribed' => $this->getUnsubscribed(),
+        ];
+    }
+}

--- a/src/DTO/Request/Contact/UpdateContact.php
+++ b/src/DTO/Request/Contact/UpdateContact.php
@@ -55,12 +55,15 @@ final class UpdateContact implements ContactInterface
 
     public function toArray(): array
     {
-        return [
-            'email' => $this->getEmail(),
-            'fields' => $this->getFields(),
-            'list_ids_included' => $this->getListIdsIncluded(),
-            'list_ids_excluded' => $this->getListIdsExcluded(),
-            'unsubscribed' => $this->getUnsubscribed(),
-        ];
+        return array_filter(
+            [
+                'email'                => $this->getEmail(),
+                'fields'               => $this->getFields(),
+                'list_ids_included'    => $this->getListIdsIncluded(),
+                'list_ids_excluded'    => $this->getListIdsExcluded(),
+                'unsubscribed'         => $this->getUnsubscribed(),
+            ],
+            fn($value) => $value !== null
+        );
     }
 }

--- a/src/MailtrapGeneralClient.php
+++ b/src/MailtrapGeneralClient.php
@@ -8,6 +8,7 @@ namespace Mailtrap;
  * @method Api\General\Account      accounts()
  * @method Api\General\User         users(int $accountId)
  * @method Api\General\Permission   permissions(int $accountId)
+ * @method Api\General\Contact      contacts(int $accountId)
  *
  * Class MailtrapGeneralClient
  */
@@ -16,6 +17,7 @@ final class MailtrapGeneralClient extends AbstractMailtrapClient
     public const API_MAPPING = [
         'accounts' => Api\General\Account::class,
         'users' => Api\General\User::class,
-        'permissions' => Api\General\Permission::class
+        'permissions' => Api\General\Permission::class,
+        'contacts' => Api\General\Contact::class,
     ];
 }

--- a/tests/Api/General/ContactTest.php
+++ b/tests/Api/General/ContactTest.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Mailtrap\Tests\Api\General;
+
+use Mailtrap\Api\AbstractApi;
+use Mailtrap\Api\General\Contact;
+use Mailtrap\DTO\Request\Contact\CreateContact;
+use Mailtrap\DTO\Request\Contact\UpdateContact;
+use Mailtrap\Exception\HttpClientException;
+use Mailtrap\Tests\MailtrapTestCase;
+use Nyholm\Psr7\Response;
+use Mailtrap\Helper\ResponseHelper;
+
+/**
+ * @covers Contact
+ *
+ * Class ContactTest
+ */
+class ContactTest extends MailtrapTestCase
+{
+    /**
+     * @var Contact|null
+     */
+    private ?Contact $contact;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->contact = $this->getMockBuilder(Contact::class)
+            ->onlyMethods(['httpGet', 'httpPost', 'httpPut', 'httpDelete'])
+            ->setConstructorArgs([$this->getConfigMock(), self::FAKE_ACCOUNT_ID])
+            ->getMock();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->contact = null;
+
+        parent::tearDown();
+    }
+
+    public function testGetAllContactLists(): void
+    {
+        $this->contact->expects($this->once())
+            ->method('httpGet')
+            ->with(AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/lists')
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($this->getExpectedContactLists())));
+
+        $response = $this->contact->getAllContactLists();
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertCount(2, $responseData);
+        $this->assertArrayHasKey('id', $responseData[0]);
+    }
+
+    public function testCreateContact(): void
+    {
+        $fakeEmail = 'test@example.com';
+        $contactDTO = new CreateContact('test@example.com', ['first_name' => 'John'], [1, 2]);
+
+        $this->contact->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts',
+                [],
+                ['contact' => $contactDTO->toArray()]
+            )
+            ->willReturn(
+                new Response(201, ['Content-Type' => 'application/json'], json_encode($this->getExpectedContactData()))
+            );
+
+        $response = $this->contact->createContact($contactDTO);
+        $responseData = ResponseHelper::toArray($response)['data'];
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertArrayHasKey('email', $responseData);
+        $this->assertEquals($fakeEmail, $responseData['email']);
+    }
+
+    public function testUpdateContactById(): void
+    {
+        $contactId = '019706a8-9612-77be-8586-4f26816b467a';
+        $contactDTO = new UpdateContact('test@example.com', ['last_name' => 'Smith'], [3], [1, 2], true);
+
+        $this->contact->expects($this->once())
+            ->method('httpPut')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/' . $contactId,
+                [],
+                ['contact' => $contactDTO->toArray()]
+            )
+            ->willReturn(
+                new Response(200, ['Content-Type' => 'application/json'], json_encode($this->getExpectedUpdateContactData()))
+            );
+
+        $response = $this->contact->updateContactById($contactId, $contactDTO);
+        $responseResult = ResponseHelper::toArray($response);
+        $responseData = $responseResult['data'];
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertArrayHasKey('data', $responseResult);
+        $this->assertArrayHasKey('action', $responseResult);
+        $this->assertEquals('updated', $responseResult['action']);
+
+        $this->assertEquals($contactId, $responseData['id']);
+        $this->assertEquals('Smith', $responseData['fields']['last_name']);
+        $this->assertEquals([3], $responseData['list_ids']);
+    }
+
+    public function testUpdateContactByEmail(): void
+    {
+        $contactEmail = 'test@example.com';
+        $contactDTO = new UpdateContact('test@example.com', ['last_name' => 'Smith'], [3], [1, 2], true);
+
+        $this->contact->expects($this->once())
+            ->method('httpPut')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/' . $contactEmail,
+                [],
+                ['contact' => $contactDTO->toArray()]
+            )
+            ->willReturn(
+                new Response(200, ['Content-Type' => 'application/json'], json_encode($this->getExpectedUpdateContactData()))
+            );
+
+        $response = $this->contact->updateContactByEmail($contactEmail, $contactDTO);
+        $responseData = ResponseHelper::toArray($response)['data'];
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals($contactEmail, $responseData['email']);
+    }
+
+    public function testDeleteContactById(): void
+    {
+        $contactId = '019706a8-9612-77be-8586-4f26816b467a';
+        $this->contact->expects($this->once())
+            ->method('httpDelete')
+            ->with(AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/' . $contactId)
+            ->willReturn(new Response(204));
+
+        $response = $this->contact->deleteContactById($contactId);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    public function testDeleteContactByEmail(): void
+    {
+        $contactEmail = 'test@example.com';
+        $this->contact->expects($this->once())
+            ->method('httpDelete')
+            ->with(AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/' . $contactEmail)
+            ->willReturn(new Response(204));
+
+        $response = $this->contact->deleteContactByEmail($contactEmail);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    public function testInvalidCreateContact(): void
+    {
+        $invalidContactDTO = new CreateContact('invalid-email');
+
+        $this->contact->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts',
+                [],
+                ['contact' => $invalidContactDTO->toArray()]
+            )
+            ->willReturn(
+                new Response(
+                    422,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['errors' => ['email' => ['is invalid']]])
+                )
+            );
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('Errors: email -> is invalid.');
+
+        $this->contact->createContact($invalidContactDTO);
+    }
+
+    private function getExpectedContactLists(): array
+    {
+        return [
+            ['id' => 1, 'name' => 'List 1'],
+            ['id' => 2, 'name' => 'List 2'],
+        ];
+    }
+
+    private function getExpectedContactData(): array
+    {
+        return [
+            'data' => [
+                'id' => '019706a8-9612-77be-8586-4f26816b467a',
+                'email' => 'test@example.com',
+                'created_at' => 1748163401202,
+                'updated_at' => 1748163401202,
+                'list_ids' => [1, 2],
+                'status' => 'subscribed',
+                'fields' => [
+                    'first_name' => 'John',
+                    'last_name' => null,
+                ],
+            ],
+        ];
+    }
+
+    private function getExpectedUpdateContactData(): array
+    {
+        return [
+            'data' => [
+                'id' => '019706a8-9612-77be-8586-4f26816b467a',
+                'email' => 'test@example.com',
+                'created_at' => 1748163401202,
+                'updated_at' => 1748163401202,
+                'list_ids' => [3],
+                'status' => 'unsubscribed',
+                'fields' => [
+                    'first_name' => 'John',
+                    'last_name' => 'Smith',
+                ],
+            ],
+            'action' => 'updated',
+        ];
+    }
+}

--- a/tests/MailtrapGeneralClientTest.php
+++ b/tests/MailtrapGeneralClientTest.php
@@ -28,7 +28,7 @@ class MailtrapGeneralClientTest extends MailtrapClientTestCase
     {
         foreach (MailtrapGeneralClient::API_MAPPING as $key => $item) {
             yield match ($key) {
-                'permissions', 'users' => [new $item($this->getConfigMock(), self::FAKE_ACCOUNT_ID)],
+                'permissions', 'users', 'contacts' => [new $item($this->getConfigMock(), self::FAKE_ACCOUNT_ID)],
                 default => [new $item($this->getConfigMock())],
             };
         }


### PR DESCRIPTION
## Motivation
Support new functionality (Contacts API)
https://help.mailtrap.io/article/147-contacts

## Changes

- Added new sub `layer` Contact into `MailtrapGeneralClient`
  - getAllContactLists
  - createContact
  - updateContact
  - deleteContact
- Added new tests
- Added examples

## How to test

```bash
composer test
```
OR run PHP code from the example
```php
(new MailtrapGeneralClient($config))
    ->contacts($accountId)
    ->getAllContactLists();
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced Contacts API functionality for managing contacts within an account.
  - Added methods for creating, updating, retrieving contact lists, and deleting contacts.
  - Included a new example script demonstrating contact management operations.
- **Documentation**
  - Updated changelog to include the new Contacts API feature.
- **Tests**
  - Added extensive tests covering contact list retrieval, contact creation, updates, deletion, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->