### PR TITLE
Email Sending Suppressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.3.0] - 2025-06-17
+- Add Email Sending Suppressions API
+
 ## [3.2.0] - 2025-06-12
 - Add Get contact API endpoint
 - Add Email Templates API functionality

--- a/examples/sending/suppressions.php
+++ b/examples/sending/suppressions.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Mailtrap\Config;
+use Mailtrap\Helper\ResponseHelper;
+use Mailtrap\MailtrapSendingClient;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$accountId = getenv('MAILTRAP_ACCOUNT_ID');
+$config = new Config(getenv('MAILTRAP_API_KEY')); // Your API token from https://mailtrap.io/api-tokens
+$mailtrapSuppression = (new MailtrapSendingClient($config))->suppressions($accountId);
+
+/**
+ * Get all Suppressions.
+ *
+ * GET https://mailtrap.io/api/accounts/{account_id}/suppressions
+ */
+try {
+    // The endpoint returns up to 1000 suppressions per request.
+    $response = $mailtrapSuppression->getSuppressions();
+
+    // OR get suppressions by email
+    $response = $mailtrapSuppression->getSuppressions('some_email@mail.com');
+
+    // Print the response body (array)
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+
+/**
+ * Delete Suppression by ID.
+ *
+ * DELETE https://mailtrap.io/api/accounts/{account_id}/suppressions/{suppression_id}
+ */
+try {
+    // Delete a suppression by ID (UUID)
+    $suppressionId = '019706a8-0000-0000-0000-4f26816b467a'; // Replace with a valid suppression ID
+    $response = $mailtrapSuppression->deleteSuppression($suppressionId);
+
+    // Print the response status code
+    var_dump($response->getStatusCode());
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}

--- a/src/Api/Sending/Suppression.php
+++ b/src/Api/Sending/Suppression.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\Api\Sending;
+
+use Mailtrap\Api\AbstractApi;
+use Mailtrap\ConfigInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class Suppression
+ */
+class Suppression extends AbstractApi implements SendingInterface
+{
+    public function __construct(ConfigInterface $config, private int $accountId)
+    {
+        parent::__construct($config);
+    }
+
+    /**
+     * List and search suppressions by email. The endpoint returns up to 1000 suppressions per request.
+     *
+     * @param string|null $email The email to filter suppressions by, or null to get all.
+     * @return ResponseInterface
+     */
+    public function getSuppressions(?string $email = null): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpGet(
+                $this->getBasePath(),
+                $email ? ['email' => $email] : []
+            )
+        );
+    }
+
+    /**
+     * Delete a suppression by ID (UUID).
+     * Mailtrap will no longer prevent sending to this email unless it's recorded in suppressions again.
+     *
+     * @param string $suppressionId
+     * @return ResponseInterface
+     */
+    public function deleteSuppression(string $suppressionId): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpDelete(
+                sprintf('%s/%s', $this->getBasePath(), $suppressionId)
+            )
+        );
+    }
+
+    private function getBasePath(): string
+    {
+        return sprintf('%s/api/accounts/%s/suppressions', $this->getHost(), $this->accountId);
+    }
+}

--- a/src/MailtrapSendingClient.php
+++ b/src/MailtrapSendingClient.php
@@ -6,6 +6,7 @@ namespace Mailtrap;
 
 /**
  * @method  Api\Sending\Emails   emails()
+ * @method  Api\Sending\Suppression suppressions(int $accountId)
  *
  * Class MailtrapSendingClient
  */
@@ -13,5 +14,6 @@ final class MailtrapSendingClient extends AbstractMailtrapClient implements Emai
 {
     public const API_MAPPING = [
         'emails' => Api\Sending\Emails::class,
+        'suppressions' => Api\Sending\Suppression::class,
     ];
 }

--- a/tests/Api/Sending/SuppressionTest.php
+++ b/tests/Api/Sending/SuppressionTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\Tests\Api\Sending;
+
+use Mailtrap\Api\AbstractApi;
+use Mailtrap\Api\Sending\Suppression;
+use Mailtrap\Exception\HttpClientException;
+use Mailtrap\Tests\MailtrapTestCase;
+use Nyholm\Psr7\Response;
+
+/**
+ * @covers Suppression
+ *
+ * Class SuppressionTest
+ */
+class SuppressionTest extends MailtrapTestCase
+{
+    private ?Suppression $suppression;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->suppression = $this->getMockBuilder(Suppression::class)
+            ->onlyMethods(['httpGet', 'httpDelete'])
+            ->setConstructorArgs([$this->getConfigMock(), self::FAKE_ACCOUNT_ID])
+            ->getMock();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->suppression = null;
+        parent::tearDown();
+    }
+
+    public function testGetSuppressionsWithoutEmail(): void
+    {
+        $expectedResponseBody = $this->getExpectedResponse('john_6832ebeadcf31@example.com');
+
+        $this->suppression->expects($this->once())
+            ->method('httpGet')
+            ->with(AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/suppressions')
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], $expectedResponseBody));
+
+        $response = $this->suppression->getSuppressions();
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertJson($response->getBody()->getContents());
+    }
+
+    public function testGetSuppressionsWithEmail(): void
+    {
+        $email = 'test@mail.com';
+        $expectedResponseBody = $this->getExpectedResponse($email);
+
+        $this->suppression->expects($this->once())
+            ->method('httpGet')
+            ->with(AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/suppressions', ['email' => $email])
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], $expectedResponseBody));
+
+        $response = $this->suppression->getSuppressions($email);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertJson($response->getBody()->getContents());
+    }
+
+    public function testDeleteSuppression(): void
+    {
+        $suppressionId = '25594eef-87e0-49c7-a647-cc316f9fdb42';
+
+        $this->suppression->expects($this->once())
+            ->method('httpDelete')
+            ->with(AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/suppressions/' . $suppressionId)
+            ->willReturn(new Response(200));
+
+        $response = $this->suppression->deleteSuppression($suppressionId);
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testDeleteSuppressionNotFound(): void
+    {
+        $suppressionId = 'non-existent-id';
+        $expectedErrorResponse = [
+            'error' => 'Suppression not found',
+        ];
+
+        $this->suppression->expects($this->once())
+            ->method('httpDelete')
+            ->with(AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/suppressions/' . $suppressionId)
+            ->willReturn(
+                new Response(404, ['Content-Type' => 'application/json'], json_encode($expectedErrorResponse))
+            );
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('The requested entity has not been found. Errors: Suppression not found.');
+
+        $this->suppression->deleteSuppression($suppressionId);
+    }
+
+    private function getExpectedResponse(string $email): string
+    {
+        return json_encode([
+            [
+               "id" => "25594eef-87e0-49c7-a647-cc316f9fdb42",
+               "type" => "unsubscription",
+               "created_at" => "2025-05-25T10:07:49Z",
+               "email" => $email,
+               "sending_stream" => "bulk",
+               "domain_name" => "",
+               "message_bounce_category" => "",
+               "message_category" => "",
+               "message_client_ip" => "",
+               "message_created_at" => "",
+               "message_esp_response" => "",
+               "message_esp_server_type" => "",
+               "message_outgoing_ip" => "",
+               "message_recipient_mx_name" => "",
+               "message_sender_email" => "",
+               "message_subject" => "",
+            ],
+        ]);
+    }
+}

--- a/tests/MailtrapSendingClientTest.php
+++ b/tests/MailtrapSendingClientTest.php
@@ -28,8 +28,11 @@ class MailtrapSendingClientTest extends MailtrapClientTestCase
 
     public function mapInstancesProvider(): iterable
     {
-        foreach (MailtrapSendingClient::API_MAPPING as $item) {
-            yield [new $item($this->getConfigMock())];
+        foreach (MailtrapSendingClient::API_MAPPING as $key => $item) {
+            yield match ($key) {
+                'suppressions' => [new $item($this->getConfigMock(), self::FAKE_ACCOUNT_ID)],
+                default => [new $item($this->getConfigMock())],
+            };
         }
     }
 


### PR DESCRIPTION
## Motivation
Support new functionality (Suppressions list)
https://help.mailtrap.io/article/95-suppressions-list

## Changes

- Added new sub `layer` Suppressions into `MailtrapSendingClient`
  - getSuppressions
  - deleteSuppression
- Added new tests
- Added examples

## How to test

```bash
composer test
```
OR run PHP code from the example
```php
(new MailtrapSendingClient($config))->suppressions($accountId)->getSuppressions();
```