### PR TITLE
[3.6.0] Contacts Batch API Import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [3.6.0] - 2025-07-15
+- Add Contact Imports API functionality
+
 ## [3.5.0] - 2025-07-12
 - Add Contact Fields API functionality
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Currently with this SDK you can:
   - Fields CRUD
   - Contacts CRUD
   - Lists CRUD
+  - Import
 - General
   - Templates CRUD
   - Suppressions management (find and delete)

--- a/examples/general/contacts.php
+++ b/examples/general/contacts.php
@@ -275,7 +275,10 @@ try {
 
 
 /**
- * Import contacts in bulk.
+ * Import contacts in bulk with support for custom fields and list management.
+ * Existing contacts with matching email addresses will be updated automatically.
+ * You can import up to 50,000 contacts per request.
+ * The import process runs asynchronously - use the returned import ID to check the status and results.
  *
  * POST https://mailtrap.io/api/accounts/{account_id}/contacts/imports
  */

--- a/examples/general/contacts.php
+++ b/examples/general/contacts.php
@@ -2,6 +2,7 @@
 
 use Mailtrap\Config;
 use Mailtrap\DTO\Request\Contact\CreateContact;
+use Mailtrap\DTO\Request\Contact\ImportContact;
 use Mailtrap\DTO\Request\Contact\UpdateContact;
 use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapGeneralClient;
@@ -268,6 +269,51 @@ try {
 
     // Print the response status code
     var_dump($response->getStatusCode());
+} catch (Exception $e) {
+    echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
+}
+
+
+/**
+ * Import contacts in bulk.
+ *
+ * POST https://mailtrap.io/api/accounts/{account_id}/contacts/imports
+ */
+try {
+    $contactsToImport = [
+        new ImportContact(
+            email: 'customer1@example.com',
+            fields: ['first_name' => 'John', 'last_name' => 'Smith', 'zip_code' => 11111],
+            listIdsIncluded: [1, 2],
+            listIdsExcluded: [4, 5]
+        ),
+        new ImportContact(
+            email: 'customer2@example.com',
+            fields: ['first_name' => 'Joe', 'last_name' => 'Doe', 'zip_code' => 22222],
+            listIdsIncluded: [1],
+            listIdsExcluded: [4]
+        ),
+    ];
+
+    $response = $contacts->importContacts($contactsToImport);
+    // print the response body (array)
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
+}
+
+
+/**
+ * Get the status of a contact import by ID.
+ *
+ * GET https://mailtrap.io/api/accounts/{account_id}/contacts/imports/{import_id}
+ */
+try {
+    $importId = 1; // Replace 1 with the actual import ID
+    $response = $contacts->getContactImport($importId);
+
+    // print the response body (array)
+    var_dump(ResponseHelper::toArray($response));
 } catch (Exception $e) {
     echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
 }

--- a/src/Api/General/Contact.php
+++ b/src/Api/General/Contact.php
@@ -9,6 +9,7 @@ use Mailtrap\ConfigInterface;
 use Mailtrap\DTO\Request\Contact\CreateContact;
 use Mailtrap\DTO\Request\Contact\ImportContact;
 use Mailtrap\DTO\Request\Contact\UpdateContact;
+use Mailtrap\Exception\InvalidArgumentException;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -255,10 +256,23 @@ class Contact extends AbstractApi implements GeneralInterface
      */
     public function importContacts(array $contacts): ResponseInterface
     {
+
         return $this->handleResponse(
             $this->httpPost(
                 path: $this->getBasePath() . '/imports',
-                body: ['contacts' => array_map(fn(ImportContact $contact) => $contact->toArray(), $contacts)]
+                body: [
+                        'contacts' => array_map(
+                            function ($contact): array {
+                                if (!$contact instanceof ImportContact) {
+                                    throw new InvalidArgumentException(
+                                        'Each contact must be an instance of ImportContact.'
+                                    );
+                                }
+                                return $contact->toArray();
+                            },
+                            $contacts
+                        )
+                    ]
             )
         );
     }

--- a/src/Api/General/Contact.php
+++ b/src/Api/General/Contact.php
@@ -7,6 +7,7 @@ namespace Mailtrap\Api\General;
 use Mailtrap\Api\AbstractApi;
 use Mailtrap\ConfigInterface;
 use Mailtrap\DTO\Request\Contact\CreateContact;
+use Mailtrap\DTO\Request\Contact\ImportContact;
 use Mailtrap\DTO\Request\Contact\UpdateContact;
 use Psr\Http\Message\ResponseInterface;
 
@@ -243,6 +244,35 @@ class Contact extends AbstractApi implements GeneralInterface
     {
         return $this->handleResponse(
             $this->httpDelete($this->getBasePath() . '/fields/' . $fieldId)
+        );
+    }
+
+    /**
+     * Import contacts in bulk.
+     *
+     * @param ImportContact[] $contacts
+     * @return ResponseInterface
+     */
+    public function importContacts(array $contacts): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpPost(
+                path: $this->getBasePath() . '/imports',
+                body: ['contacts' => array_map(fn(ImportContact $contact) => $contact->toArray(), $contacts)]
+            )
+        );
+    }
+
+    /**
+     * Get the status of a contact import by ID.
+     *
+     * @param int $importId
+     * @return ResponseInterface
+     */
+    public function getContactImport(int $importId): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpGet($this->getBasePath() . '/imports/' . $importId)
         );
     }
 

--- a/src/DTO/Request/Contact/ImportContact.php
+++ b/src/DTO/Request/Contact/ImportContact.php
@@ -48,14 +48,11 @@ final class ImportContact implements ContactInterface
 
     public function toArray(): array
     {
-        return array_filter(
-            [
-                'email'                => $this->getEmail(),
-                'fields'               => $this->getFields(),
-                'list_ids_included'    => $this->getListIdsIncluded(),
-                'list_ids_excluded'    => $this->getListIdsExcluded(),
-            ],
-            fn($value) => $value !== null
-        );
+        return [
+            'email'                => $this->getEmail(),
+            'fields'               => $this->getFields(),
+            'list_ids_included'    => $this->getListIdsIncluded(),
+            'list_ids_excluded'    => $this->getListIdsExcluded(),
+        ];
     }
 }

--- a/src/DTO/Request/Contact/ImportContact.php
+++ b/src/DTO/Request/Contact/ImportContact.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\DTO\Request\Contact;
+
+/**
+ * Class ImportContact
+ */
+final class ImportContact implements ContactInterface
+{
+    public function __construct(
+        private string $email,
+        private array $fields = [],
+        private array $listIdsIncluded = [],
+        private array $listIdsExcluded = []
+    ) {
+    }
+
+    public static function init(
+        string $email,
+        array $fields = [],
+        array $listIdsIncluded = [],
+        array $listIdsExcluded = []
+    ): self {
+        return new self($email, $fields, $listIdsIncluded, $listIdsExcluded);
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    public function getListIdsIncluded(): array
+    {
+        return $this->listIdsIncluded;
+    }
+
+    public function getListIdsExcluded(): array
+    {
+        return $this->listIdsExcluded;
+    }
+
+    public function toArray(): array
+    {
+        return array_filter(
+            [
+                'email'                => $this->getEmail(),
+                'fields'               => $this->getFields(),
+                'list_ids_included'    => $this->getListIdsIncluded(),
+                'list_ids_excluded'    => $this->getListIdsExcluded(),
+            ],
+            fn($value) => $value !== null
+        );
+    }
+}

--- a/tests/Api/General/ContactTest.php
+++ b/tests/Api/General/ContactTest.php
@@ -8,6 +8,7 @@ use Mailtrap\DTO\Request\Contact\CreateContact;
 use Mailtrap\DTO\Request\Contact\UpdateContact;
 use Mailtrap\DTO\Request\Contact\ImportContact;
 use Mailtrap\Exception\HttpClientException;
+use Mailtrap\Exception\InvalidArgumentException;
 use Mailtrap\Tests\MailtrapTestCase;
 use Nyholm\Psr7\Response;
 use Mailtrap\Helper\ResponseHelper;
@@ -622,6 +623,32 @@ class ContactTest extends MailtrapTestCase
 
         $this->expectException(HttpClientException::class);
         $this->expectExceptionMessage('Errors: email -> invalid-email. errors -> email -> is invalid. top level domain is too short.');
+
+        $this->contact->importContacts($contacts);
+    }
+
+    public function testImportContactsThrowsExceptionForInvalidInput(): void
+    {
+        $contacts = [
+            new ImportContact(
+                email: 'valid@example.com',
+                fields: ['first_name' => 'John'],
+                listIdsIncluded: [1],
+                listIdsExcluded: []
+            ),
+            // Invalid input
+            new UpdateContact(
+                email: 'valid@example.com',
+                fields: ['first_name' => 'John'],
+                listIdsIncluded: [1],
+                listIdsExcluded: []
+            ),
+        ];
+
+        $this->contact->expects($this->never())->method('httpPost');
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Each contact must be an instance of ImportContact.');
 
         $this->contact->importContacts($contacts);
     }

--- a/tests/Api/General/ContactTest.php
+++ b/tests/Api/General/ContactTest.php
@@ -6,6 +6,7 @@ use Mailtrap\Api\AbstractApi;
 use Mailtrap\Api\General\Contact;
 use Mailtrap\DTO\Request\Contact\CreateContact;
 use Mailtrap\DTO\Request\Contact\UpdateContact;
+use Mailtrap\DTO\Request\Contact\ImportContact;
 use Mailtrap\Exception\HttpClientException;
 use Mailtrap\Tests\MailtrapTestCase;
 use Nyholm\Psr7\Response;
@@ -474,6 +475,155 @@ class ContactTest extends MailtrapTestCase
         $response = $this->contact->deleteContactField($fieldId);
 
         $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    public function testImportContacts(): void
+    {
+        $contacts = [
+            new ImportContact(
+                email: 'customer1@example.com',
+                fields: ['first_name' => 'John', 'last_name' => 'Smith', 'zip_code' => 11111],
+                listIdsIncluded: [1, 2, 3],
+                listIdsExcluded: [4, 5, 6]
+            ),
+            new ImportContact(
+                email: 'customer2@example.com',
+                fields: ['first_name' => 'Joe', 'last_name' => 'Doe', 'zip_code' => 22222],
+                listIdsIncluded: [1],
+                listIdsExcluded: [4]
+            ),
+        ];
+
+        $expectedResponse = [
+            'id' => 1,
+            'status' => 'created',
+        ];
+
+        $this->contact->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/imports',
+                [],
+                ['contacts' => array_map(fn(ImportContact $contact) => $contact->toArray(), $contacts)]
+            )
+            ->willReturn(new Response(201, ['Content-Type' => 'application/json'], json_encode($expectedResponse)));
+
+        $response = $this->contact->importContacts($contacts);
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertArrayHasKey('id', $responseData);
+        $this->assertEquals(1, $responseData['id']);
+        $this->assertEquals('created', $responseData['status']);
+    }
+
+    public function testGetContactImportInProgress(): void
+    {
+        $importId = 1;
+        $expectedResponse = [
+            'id' => $importId,
+            'status' => 'created',
+        ];
+
+        $this->contact->expects($this->once())
+            ->method('httpGet')
+            ->with(AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/imports/' . $importId)
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedResponse)));
+
+        $response = $this->contact->getContactImport($importId);
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertArrayHasKey('id', $responseData);
+        $this->assertEquals($importId, $responseData['id']);
+        $this->assertEquals('created', $responseData['status']);
+    }
+
+    public function testGetContactImportFinished(): void
+    {
+        $importId = 1;
+        $expectedResponse = [
+            'id' => $importId,
+            'status' => 'finished',
+            'created_contacts_count' => 2,
+            'updated_contacts_count' => 0,
+            'contacts_over_limit_count' => 0,
+        ];
+
+        $this->contact->expects($this->once())
+            ->method('httpGet')
+            ->with(AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/imports/' . $importId)
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedResponse)));
+
+        $response = $this->contact->getContactImport($importId);
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertArrayHasKey('id', $responseData);
+        $this->assertEquals($importId, $responseData['id']);
+        $this->assertEquals('finished', $responseData['status']);
+        $this->assertEquals(2, $responseData['created_contacts_count']);
+        $this->assertEquals(0, $responseData['updated_contacts_count']);
+        $this->assertEquals(0, $responseData['contacts_over_limit_count']);
+    }
+
+    public function testGetContactImportNotFound(): void
+    {
+        $importId = 999;
+
+        $this->contact->expects($this->once())
+            ->method('httpGet')
+            ->with(AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/imports/' . $importId)
+            ->willReturn(
+                new Response(404, ['Content-Type' => 'application/json'], json_encode(['error' => 'Not Found']))
+            );
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('Errors: Not Found.');
+
+        $this->contact->getContactImport($importId);
+    }
+
+    public function testImportContactsValidationError(): void
+    {
+        $contacts = [
+            new ImportContact(
+                email: 'invalid-email',
+                fields: ['first_name' => 'John'],
+                listIdsIncluded: [],
+                listIdsExcluded: []
+            ),
+        ];
+
+        $expectedResponse = [
+            'errors' => [
+                [
+                    'email' => 'invalid-email',
+                    'errors' => [
+                        'email' => [
+                            'is invalid',
+                            'top level domain is too short',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->contact->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/imports',
+                [],
+                ['contacts' => array_map(fn(ImportContact $contact) => $contact->toArray(), $contacts)]
+            )
+            ->willReturn(
+                new Response(422, ['Content-Type' => 'application/json'], json_encode($expectedResponse))
+            );
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('Errors: email -> invalid-email. errors -> email -> is invalid. top level domain is too short.');
+
+        $this->contact->importContacts($contacts);
     }
 
     private function getExpectedContactFields(): array


### PR DESCRIPTION
## Motivation
Support new functionality (Contacts Batch Import)
https://help.mailtrap.io/article/147-contacts

## Changes

- Add Contacts Batch API Import

## How to test

```bash
composer test
```
OR run PHP code from the example
```php
(new MailtrapGeneralClient($config))
    ->contacts($accountId)
    ->importContacts(
        [
            ImportContact::init(
                uniqid('john_') . '@example.com',
                ['first_name' => 'John'],
                [1,2],
                [3,4],
            ),
            ImportContact::init(
                uniqid('jane_') . '@example.com',
                ['first_name' => 'Jane'],
                [3,4],
                [1,2],
            )
        ]
    );
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced bulk contact import functionality, allowing users to import multiple contacts with support for custom fields and list management.
  * Added the ability to check the status and results of contact imports.

* **Documentation**
  * Updated the README and changelog to reflect new contact import capabilities.
  * Added usage examples for importing contacts and retrieving import status.

* **Tests**
  * Expanded test coverage to include scenarios for contact import, status retrieval, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->