### PR TITLE
Add Stats API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [Unreleased]
+- Add Stats API with get, byDomain, byCategory, byEmailServiceProvider, byDate endpoints
+
 ## [3.9.1] - 2025-10-27
 - Improve README
 

--- a/examples/sending/stats.php
+++ b/examples/sending/stats.php
@@ -1,0 +1,97 @@
+<?php
+
+use Mailtrap\Config;
+use Mailtrap\Helper\ResponseHelper;
+use Mailtrap\MailtrapSendingClient;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$accountId = (int) $_ENV['MAILTRAP_ACCOUNT_ID'];
+$config = new Config($_ENV['MAILTRAP_API_KEY']); #your API token from here https://mailtrap.io/api-tokens
+$stats = (new MailtrapSendingClient($config))->stats($accountId);
+
+/**
+ * Get aggregated sending stats.
+ *
+ * GET https://mailtrap.io/api/accounts/{account_id}/stats
+ */
+try {
+    $response = $stats->get('2026-01-01', '2026-01-31');
+
+    // print the response body (array)
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Get aggregated sending stats with filters.
+ *
+ * GET https://mailtrap.io/api/accounts/{account_id}/stats
+ */
+try {
+    $response = $stats->get(
+        '2026-01-01',
+        '2026-01-31',
+        sendingDomainIds: [1, 2],
+        sendingStreams: ['transactional'],
+        categories: ['Transactional', 'Marketing'],
+        emailServiceProviders: ['Gmail', 'Yahoo']
+    );
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Get sending stats grouped by domains.
+ *
+ * GET https://mailtrap.io/api/accounts/{account_id}/stats/domains
+ */
+try {
+    $response = $stats->byDomain('2026-01-01', '2026-01-31');
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Get sending stats grouped by categories.
+ *
+ * GET https://mailtrap.io/api/accounts/{account_id}/stats/categories
+ */
+try {
+    $response = $stats->byCategory('2026-01-01', '2026-01-31');
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Get sending stats grouped by email service providers.
+ *
+ * GET https://mailtrap.io/api/accounts/{account_id}/stats/email_service_providers
+ */
+try {
+    $response = $stats->byEmailServiceProvider('2026-01-01', '2026-01-31');
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Get sending stats grouped by date.
+ *
+ * GET https://mailtrap.io/api/accounts/{account_id}/stats/date
+ */
+try {
+    $response = $stats->byDate('2026-01-01', '2026-01-31');
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
+}

--- a/src/Api/Sending/Stats.php
+++ b/src/Api/Sending/Stats.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\Api\Sending;
+
+use Mailtrap\Api\AbstractApi;
+use Mailtrap\ConfigInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class Stats
+ */
+class Stats extends AbstractApi implements SendingInterface
+{
+    public function __construct(ConfigInterface $config, private int $accountId)
+    {
+        parent::__construct($config);
+    }
+
+    /**
+     * Get aggregated sending stats.
+     *
+     * @param string $startDate
+     * @param string $endDate
+     * @param array  $sendingDomainIds
+     * @param array  $sendingStreams
+     * @param array  $categories
+     * @param array  $emailServiceProviders
+     *
+     * @return ResponseInterface
+     */
+    public function get(
+        string $startDate,
+        string $endDate,
+        array $sendingDomainIds = [],
+        array $sendingStreams = [],
+        array $categories = [],
+        array $emailServiceProviders = []
+    ): ResponseInterface {
+        return $this->handleResponse($this->httpGet(
+            $this->getBasePath(),
+            $this->buildQueryParams($startDate, $endDate, $sendingDomainIds, $sendingStreams, $categories, $emailServiceProviders)
+        ));
+    }
+
+    /**
+     * Get sending stats grouped by domains.
+     *
+     * @param string $startDate
+     * @param string $endDate
+     * @param array  $sendingDomainIds
+     * @param array  $sendingStreams
+     * @param array  $categories
+     * @param array  $emailServiceProviders
+     *
+     * @return ResponseInterface
+     */
+    public function byDomain(
+        string $startDate,
+        string $endDate,
+        array $sendingDomainIds = [],
+        array $sendingStreams = [],
+        array $categories = [],
+        array $emailServiceProviders = []
+    ): ResponseInterface {
+        return $this->handleResponse($this->httpGet(
+            $this->getBasePath() . '/domains',
+            $this->buildQueryParams($startDate, $endDate, $sendingDomainIds, $sendingStreams, $categories, $emailServiceProviders)
+        ));
+    }
+
+    /**
+     * Get sending stats grouped by categories.
+     *
+     * @param string $startDate
+     * @param string $endDate
+     * @param array  $sendingDomainIds
+     * @param array  $sendingStreams
+     * @param array  $categories
+     * @param array  $emailServiceProviders
+     *
+     * @return ResponseInterface
+     */
+    public function byCategory(
+        string $startDate,
+        string $endDate,
+        array $sendingDomainIds = [],
+        array $sendingStreams = [],
+        array $categories = [],
+        array $emailServiceProviders = []
+    ): ResponseInterface {
+        return $this->handleResponse($this->httpGet(
+            $this->getBasePath() . '/categories',
+            $this->buildQueryParams($startDate, $endDate, $sendingDomainIds, $sendingStreams, $categories, $emailServiceProviders)
+        ));
+    }
+
+    /**
+     * Get sending stats grouped by email service providers.
+     *
+     * @param string $startDate
+     * @param string $endDate
+     * @param array  $sendingDomainIds
+     * @param array  $sendingStreams
+     * @param array  $categories
+     * @param array  $emailServiceProviders
+     *
+     * @return ResponseInterface
+     */
+    public function byEmailServiceProvider(
+        string $startDate,
+        string $endDate,
+        array $sendingDomainIds = [],
+        array $sendingStreams = [],
+        array $categories = [],
+        array $emailServiceProviders = []
+    ): ResponseInterface {
+        return $this->handleResponse($this->httpGet(
+            $this->getBasePath() . '/email_service_providers',
+            $this->buildQueryParams($startDate, $endDate, $sendingDomainIds, $sendingStreams, $categories, $emailServiceProviders)
+        ));
+    }
+
+    /**
+     * Get sending stats grouped by date.
+     *
+     * @param string $startDate
+     * @param string $endDate
+     * @param array  $sendingDomainIds
+     * @param array  $sendingStreams
+     * @param array  $categories
+     * @param array  $emailServiceProviders
+     *
+     * @return ResponseInterface
+     */
+    public function byDate(
+        string $startDate,
+        string $endDate,
+        array $sendingDomainIds = [],
+        array $sendingStreams = [],
+        array $categories = [],
+        array $emailServiceProviders = []
+    ): ResponseInterface {
+        return $this->handleResponse($this->httpGet(
+            $this->getBasePath() . '/date',
+            $this->buildQueryParams($startDate, $endDate, $sendingDomainIds, $sendingStreams, $categories, $emailServiceProviders)
+        ));
+    }
+
+    public function getAccountId(): int
+    {
+        return $this->accountId;
+    }
+
+    private function getBasePath(): string
+    {
+        return sprintf('%s/api/accounts/%s/stats', $this->getHost(), $this->getAccountId());
+    }
+
+    private function buildQueryParams(
+        string $startDate,
+        string $endDate,
+        array $sendingDomainIds,
+        array $sendingStreams,
+        array $categories,
+        array $emailServiceProviders
+    ): array {
+        $params = [
+            'start_date' => $startDate,
+            'end_date' => $endDate,
+        ];
+
+        if (count($sendingDomainIds) > 0) {
+            $params['sending_domain_ids'] = $sendingDomainIds;
+        }
+
+        if (count($sendingStreams) > 0) {
+            $params['sending_streams'] = $sendingStreams;
+        }
+
+        if (count($categories) > 0) {
+            $params['categories'] = $categories;
+        }
+
+        if (count($emailServiceProviders) > 0) {
+            $params['email_service_providers'] = $emailServiceProviders;
+        }
+
+        return $params;
+    }
+}

--- a/src/MailtrapSendingClient.php
+++ b/src/MailtrapSendingClient.php
@@ -8,6 +8,7 @@ namespace Mailtrap;
  * @method  Api\Sending\Emails      emails()
  * @method  Api\Sending\Suppression suppressions(int $accountId)
  * @method  Api\Sending\Domain      domains(int $accountId)
+ * @method  Api\Sending\Stats       stats(int $accountId)
  *
  * Class MailtrapSendingClient
  */
@@ -17,5 +18,6 @@ final class MailtrapSendingClient extends AbstractMailtrapClient implements Emai
         'emails' => Api\Sending\Emails::class,
         'suppressions' => Api\Sending\Suppression::class,
         'domains' => Api\Sending\Domain::class,
+        'stats' => Api\Sending\Stats::class,
     ];
 }

--- a/tests/Api/Sending/StatsTest.php
+++ b/tests/Api/Sending/StatsTest.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\Tests\Api\Sending;
+
+use Mailtrap\Api\AbstractApi;
+use Mailtrap\Api\Sending\Stats;
+use Mailtrap\Exception\HttpClientException;
+use Mailtrap\Helper\ResponseHelper;
+use Mailtrap\Tests\MailtrapTestCase;
+use Nyholm\Psr7\Response;
+
+/**
+ * @covers Stats
+ *
+ * Class StatsTest
+ */
+class StatsTest extends MailtrapTestCase
+{
+    private ?Stats $stats;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->stats = $this->getMockBuilder(Stats::class)
+            ->onlyMethods(['httpGet'])
+            ->setConstructorArgs([$this->getConfigMock(), self::FAKE_ACCOUNT_ID])
+            ->getMock();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->stats = null;
+
+        parent::tearDown();
+    }
+
+    public function testGet(): void
+    {
+        $expectedData = $this->getSampleStatsData();
+
+        $this->stats->expects($this->once())
+            ->method('httpGet')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/stats',
+                ['start_date' => '2026-01-01', 'end_date' => '2026-01-31']
+            )
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedData)));
+
+        $response = $this->stats->get('2026-01-01', '2026-01-31');
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals(150, $responseData['delivery_count']);
+        $this->assertEquals(0.95, $responseData['delivery_rate']);
+        $this->assertEquals(8, $responseData['bounce_count']);
+        $this->assertEquals(120, $responseData['open_count']);
+        $this->assertEquals(60, $responseData['click_count']);
+        $this->assertEquals(2, $responseData['spam_count']);
+    }
+
+    public function testGetWithFilters(): void
+    {
+        $expectedData = $this->getSampleStatsData();
+
+        $this->stats->expects($this->once())
+            ->method('httpGet')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/stats',
+                [
+                    'start_date' => '2026-01-01',
+                    'end_date' => '2026-01-31',
+                    'sending_domain_ids' => [1, 2],
+                    'sending_streams' => ['transactional'],
+                    'categories' => ['Transactional'],
+                    'email_service_providers' => ['Gmail'],
+                ]
+            )
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedData)));
+
+        $response = $this->stats->get(
+            '2026-01-01',
+            '2026-01-31',
+            [1, 2],
+            ['transactional'],
+            ['Transactional'],
+            ['Gmail']
+        );
+
+        $this->assertInstanceOf(Response::class, $response);
+    }
+
+    public function testGetForbidden(): void
+    {
+        $this->stats->expects($this->once())
+            ->method('httpGet')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/stats',
+                ['start_date' => '2026-01-01', 'end_date' => '2026-01-31']
+            )
+            ->willReturn(
+                new Response(403, ['Content-Type' => 'application/json'], json_encode(['errors' => 'Access forbidden']))
+            );
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage(
+            'Forbidden. Make sure domain verification process is completed or check your permissions. Errors: Access forbidden.'
+        );
+
+        $this->stats->get('2026-01-01', '2026-01-31');
+    }
+
+    public function testByDomain(): void
+    {
+        $expectedData = $this->getSampleGroupedByDomainsData();
+
+        $this->stats->expects($this->once())
+            ->method('httpGet')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/stats/domains',
+                ['start_date' => '2026-01-01', 'end_date' => '2026-01-31']
+            )
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedData)));
+
+        $response = $this->stats->byDomain('2026-01-01', '2026-01-31');
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertCount(2, $responseData);
+        $this->assertEquals(1, $responseData[0]['sending_domain_id']);
+        $this->assertEquals(100, $responseData[0]['stats']['delivery_count']);
+        $this->assertEquals(2, $responseData[1]['sending_domain_id']);
+        $this->assertEquals(50, $responseData[1]['stats']['delivery_count']);
+    }
+
+    public function testByCategory(): void
+    {
+        $expectedData = [
+            [
+                'category' => 'Transactional',
+                'stats' => [
+                    'delivery_count' => 100, 'delivery_rate' => 0.97,
+                    'bounce_count' => 3, 'bounce_rate' => 0.03,
+                    'open_count' => 85, 'open_rate' => 0.85,
+                    'click_count' => 45, 'click_rate' => 0.53,
+                    'spam_count' => 0, 'spam_rate' => 0.0,
+                ],
+            ],
+        ];
+
+        $this->stats->expects($this->once())
+            ->method('httpGet')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/stats/categories',
+                ['start_date' => '2026-01-01', 'end_date' => '2026-01-31']
+            )
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedData)));
+
+        $response = $this->stats->byCategory('2026-01-01', '2026-01-31');
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals('Transactional', $responseData[0]['category']);
+        $this->assertEquals(100, $responseData[0]['stats']['delivery_count']);
+    }
+
+    public function testByEmailServiceProvider(): void
+    {
+        $expectedData = [
+            [
+                'email_service_provider' => 'Gmail',
+                'stats' => [
+                    'delivery_count' => 80, 'delivery_rate' => 0.97,
+                    'bounce_count' => 2, 'bounce_rate' => 0.03,
+                    'open_count' => 70, 'open_rate' => 0.88,
+                    'click_count' => 35, 'click_rate' => 0.5,
+                    'spam_count' => 1, 'spam_rate' => 0.013,
+                ],
+            ],
+        ];
+
+        $this->stats->expects($this->once())
+            ->method('httpGet')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/stats/email_service_providers',
+                ['start_date' => '2026-01-01', 'end_date' => '2026-01-31']
+            )
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedData)));
+
+        $response = $this->stats->byEmailServiceProvider('2026-01-01', '2026-01-31');
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals('Gmail', $responseData[0]['email_service_provider']);
+        $this->assertEquals(80, $responseData[0]['stats']['delivery_count']);
+    }
+
+    public function testByDate(): void
+    {
+        $expectedData = [
+            [
+                'date' => '2026-01-01',
+                'stats' => [
+                    'delivery_count' => 5, 'delivery_rate' => 1.0,
+                    'bounce_count' => 0, 'bounce_rate' => 0.0,
+                    'open_count' => 4, 'open_rate' => 0.8,
+                    'click_count' => 2, 'click_rate' => 0.5,
+                    'spam_count' => 0, 'spam_rate' => 0.0,
+                ],
+            ],
+        ];
+
+        $this->stats->expects($this->once())
+            ->method('httpGet')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/stats/date',
+                ['start_date' => '2026-01-01', 'end_date' => '2026-01-31']
+            )
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($expectedData)));
+
+        $response = $this->stats->byDate('2026-01-01', '2026-01-31');
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertEquals('2026-01-01', $responseData[0]['date']);
+        $this->assertEquals(5, $responseData[0]['stats']['delivery_count']);
+    }
+
+    private function getSampleStatsData(): array
+    {
+        return [
+            'delivery_count' => 150, 'delivery_rate' => 0.95,
+            'bounce_count' => 8, 'bounce_rate' => 0.05,
+            'open_count' => 120, 'open_rate' => 0.8,
+            'click_count' => 60, 'click_rate' => 0.5,
+            'spam_count' => 2, 'spam_rate' => 0.013,
+        ];
+    }
+
+    private function getSampleGroupedByDomainsData(): array
+    {
+        return [
+            [
+                'sending_domain_id' => 1,
+                'stats' => [
+                    'delivery_count' => 100, 'delivery_rate' => 0.96,
+                    'bounce_count' => 4, 'bounce_rate' => 0.04,
+                    'open_count' => 80, 'open_rate' => 0.8,
+                    'click_count' => 40, 'click_rate' => 0.5,
+                    'spam_count' => 1, 'spam_rate' => 0.01,
+                ],
+            ],
+            [
+                'sending_domain_id' => 2,
+                'stats' => [
+                    'delivery_count' => 50, 'delivery_rate' => 0.93,
+                    'bounce_count' => 4, 'bounce_rate' => 0.07,
+                    'open_count' => 40, 'open_rate' => 0.8,
+                    'click_count' => 20, 'click_rate' => 0.5,
+                    'spam_count' => 1, 'spam_rate' => 0.02,
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/MailtrapSendingClientTest.php
+++ b/tests/MailtrapSendingClientTest.php
@@ -30,7 +30,7 @@ class MailtrapSendingClientTest extends MailtrapClientTestCase
     {
         foreach (MailtrapSendingClient::API_MAPPING as $key => $item) {
             yield match ($key) {
-                'suppressions', 'domains' => [new $item($this->getConfigMock(), self::FAKE_ACCOUNT_ID)],
+                'suppressions', 'domains', 'stats' => [new $item($this->getConfigMock(), self::FAKE_ACCOUNT_ID)],
                 default => [new $item($this->getConfigMock())],
             };
         }


### PR DESCRIPTION
## Motivation

- Add support for the Email Sending Stats API (`/api/accounts/{account_id}/stats`) to the PHP SDK, enabling users to retrieve aggregated email sending statistics.

## Changes

- Add Stats class extending AbstractApi with 5 methods: get, byDomain, byCategory, byEmailServiceProvider, byDate
- Add query param handling for array filters (sending_domain_ids, sending_streams, categories, email_service_providers)
- Add usage example in examples/sending/stats.php
- Update README with Stats API reference
- Update CHANGELOG with v3.10.0 entry

## How to test

- $stats->get($startDate, $endDate) with different parameters (sendingDomainIds, sendingStreams, categories, emailServiceProviders)
- Test grouped endpoints (byDomain, byCategory, byEmailServiceProvider, byDate) with filters

## Examples

```php
use Mailtrap\Config;
use Mailtrap\Helper\ResponseHelper;
use Mailtrap\MailtrapSendingClient;

$config = new Config('api_key');
$stats = (new MailtrapSendingClient($config))->stats($accountId);

// Get aggregated stats
$response = $stats->get('2026-01-01', '2026-01-31');
var_dump(ResponseHelper::toArray($response));

// Get stats with optional filters
$response = $stats->get(
    '2026-01-01',
    '2026-01-31',
    sendingDomainIds: [1, 2],
    sendingStreams: ['transactional'],
    categories: ['Welcome email'],
    emailServiceProviders: ['Gmail', 'Yahoo']
);

// Get stats grouped by date
$response = $stats->byDate('2026-01-01', '2026-01-02');

// Get stats grouped by categories
$response = $stats->byCategory('2026-01-01', '2026-01-02');

// Get stats grouped by email service providers with filters
$response = $stats->byEmailServiceProvider(
    '2026-01-01',
    '2026-01-02',
    categories: ['Welcome email']
);

// Get stats grouped by domains with filters
$response = $stats->byDomain(
    '2026-01-01',
    '2026-01-02',
    categories: ['Welcome email'],
    emailServiceProviders: ['Google']
);
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Stats API for aggregated sending statistics (overall, by domain, category, email service provider, and date) with optional filters across date ranges; exposed via the client.

* **Documentation**
  * Added a PHP example demonstrating Stats API usage and filtering.

* **Tests**
  * Added a test suite validating Stats API behaviors and error handling.

* **Chore**
  * Updated changelog with Unreleased Stats API entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->