### PR TITLE
Add support for Email Logs API

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ Email API:
 - Batch send with Template (Transactional) – [`batch/transactional_template.php`](examples/batch/transactional_template.php)
 - Batch send with Template (Bulk) – [`batch/bulk_template.php`](examples/batch/bulk_template.php)
 - Sending domain management CRUD – [`sending-domains/all.php`](examples/sending-domains/all.php)
+- Suppressions (find & delete) – [`sending/suppressions.php`](examples/sending/suppressions.php)
+- Email Logs (list & get by message ID) – [`sending/email-logs.php`](examples/sending/email-logs.php)
 
 Email Sandbox (Testing):
 - Send an email (Sandbox) – [`testing/send-mail.php`](examples/testing/send-mail.php)
@@ -260,7 +262,6 @@ Contact management:
 
 General API:
 - Templates CRUD – [`templates/all.php`](examples/templates/all.php)
-- Suppressions (find & delete) – [`sending/suppressions.php`](examples/sending/suppressions.php)
 - Billing info – [`general/billing.php`](examples/general/billing.php)
 - Accounts info – [`general/accounts.php`](examples/general/accounts.php)
 - Permissions listing – [`general/permissions.php`](examples/general/permissions.php)

--- a/examples/batch/bulk.php
+++ b/examples/batch/bulk.php
@@ -5,7 +5,7 @@ use Mailtrap\MailtrapClient;
 use Mailtrap\Mime\MailtrapEmail;
 use Symfony\Component\Mime\Address;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 /**
  * Email Batch Sending API (Bulk)

--- a/examples/batch/bulk_template.php
+++ b/examples/batch/bulk_template.php
@@ -5,7 +5,7 @@ use Mailtrap\MailtrapClient;
 use Mailtrap\Mime\MailtrapEmail;
 use Symfony\Component\Mime\Address;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 /**
  * Email Batch Sending WITH TEMPLATE (Bulk)

--- a/examples/batch/sandbox.php
+++ b/examples/batch/sandbox.php
@@ -5,7 +5,7 @@ use Mailtrap\MailtrapClient;
 use Mailtrap\Mime\MailtrapEmail;
 use Symfony\Component\Mime\Address;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 /**
  * Test Email Batch

--- a/examples/batch/sandbox_template.php
+++ b/examples/batch/sandbox_template.php
@@ -5,7 +5,7 @@ use Mailtrap\MailtrapClient;
 use Mailtrap\Mime\MailtrapEmail;
 use Symfony\Component\Mime\Address;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 /**
  * Test Email Batch WITH TEMPLATE

--- a/examples/batch/transactional.php
+++ b/examples/batch/transactional.php
@@ -5,7 +5,7 @@ use Mailtrap\MailtrapClient;
 use Mailtrap\Mime\MailtrapEmail;
 use Symfony\Component\Mime\Address;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 /**
  * Email Batch Sending API (Transactional)

--- a/examples/batch/transactional_template.php
+++ b/examples/batch/transactional_template.php
@@ -5,7 +5,7 @@ use Mailtrap\MailtrapClient;
 use Mailtrap\Mime\MailtrapEmail;
 use Symfony\Component\Mime\Address;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 /**
  * Email Batch Sending WITH TEMPLATE (Transactional)

--- a/examples/bulk/bulk.php
+++ b/examples/bulk/bulk.php
@@ -7,7 +7,7 @@ use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 /**
  * Email Bulk Sending API

--- a/examples/bulk/bulk_template.php
+++ b/examples/bulk/bulk_template.php
@@ -5,7 +5,7 @@ use Mailtrap\MailtrapClient;
 use Mailtrap\Mime\MailtrapEmail;
 use Symfony\Component\Mime\Address;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 /**
  * Email Bulk Sending WITH TEMPLATE

--- a/examples/config/all.php
+++ b/examples/config/all.php
@@ -8,7 +8,7 @@ use Mailtrap\Mime\MailtrapEmail;
 use Symfony\Component\HttpClient\Psr18Client;
 use Symfony\Component\Mime\Address;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 
 $apiToken = $_ENV['MAILTRAP_API_KEY'];

--- a/examples/contact-fields/all.php
+++ b/examples/contact-fields/all.php
@@ -9,7 +9,7 @@ use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapGeneralClient;
 use Mailtrap\DTO\Request\Contact\ContactExportFilter;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 $accountId = $_ENV['MAILTRAP_ACCOUNT_ID'];
 $config = new Config($_ENV['MAILTRAP_API_KEY']); #your API token from here https://mailtrap.io/api-tokens

--- a/examples/contact-lists/all.php
+++ b/examples/contact-lists/all.php
@@ -9,7 +9,7 @@ use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapGeneralClient;
 use Mailtrap\DTO\Request\Contact\ContactExportFilter;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 $accountId = $_ENV['MAILTRAP_ACCOUNT_ID'];
 $config = new Config($_ENV['MAILTRAP_API_KEY']); #your API token from here https://mailtrap.io/api-tokens

--- a/examples/contacts/all.php
+++ b/examples/contacts/all.php
@@ -9,7 +9,7 @@ use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapGeneralClient;
 use Mailtrap\DTO\Request\Contact\ContactExportFilter;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 $accountId = $_ENV['MAILTRAP_ACCOUNT_ID'];
 $config = new Config($_ENV['MAILTRAP_API_KEY']); #your API token from here https://mailtrap.io/api-tokens

--- a/examples/general/accounts.php
+++ b/examples/general/accounts.php
@@ -4,7 +4,7 @@ use Mailtrap\Config;
 use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapGeneralClient;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 $config = new Config($_ENV['MAILTRAP_API_KEY']); #your API token from here https://mailtrap.io/api-tokens
 $generalAccounts = (new MailtrapGeneralClient($config))->accounts();

--- a/examples/general/billing.php
+++ b/examples/general/billing.php
@@ -4,7 +4,7 @@ use Mailtrap\Config;
 use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapGeneralClient;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 $accountId = (int) $_ENV['MAILTRAP_ACCOUNT_ID'];
 $config = new Config($_ENV['MAILTRAP_API_KEY']); #your API token from here https://mailtrap.io/api-tokens

--- a/examples/general/permissions.php
+++ b/examples/general/permissions.php
@@ -8,7 +8,7 @@ use Mailtrap\DTO\Request\Permission\Permissions;
 use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapGeneralClient;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 $accountId = $_ENV['MAILTRAP_ACCOUNT_ID'];
 $config = new Config($_ENV['MAILTRAP_API_KEY']); #your API token from here https://mailtrap.io/api-tokens

--- a/examples/general/users.php
+++ b/examples/general/users.php
@@ -4,7 +4,7 @@ use Mailtrap\Config;
 use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapGeneralClient;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 $accountId = $_ENV['MAILTRAP_ACCOUNT_ID'];
 $config = new Config($_ENV['MAILTRAP_API_KEY']); #your API token from here https://mailtrap.io/api-tokens

--- a/examples/sending/all.php
+++ b/examples/sending/all.php
@@ -7,7 +7,7 @@ use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 
 /**

--- a/examples/sending/email-logs.php
+++ b/examples/sending/email-logs.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Mailtrap\Config;
+use Mailtrap\DTO\Request\EmailLogs\EmailLogsListFilters;
+use Mailtrap\DTO\Request\EmailLogs\FilterCriterion;
+use Mailtrap\DTO\Request\EmailLogs\EmailLogsFilterOperator;
+use Mailtrap\Helper\ResponseHelper;
+use Mailtrap\MailtrapSendingClient;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$accountId = (int) $_ENV['MAILTRAP_ACCOUNT_ID'];
+$config = new Config($_ENV['MAILTRAP_API_KEY']);
+$emailLogs = (new MailtrapSendingClient($config))->emailLogs($accountId);
+
+/**
+ * List email logs (paginated).
+ *
+ * GET https://mailtrap.io/api/accounts/{account_id}/email_logs
+ */
+try {
+    // Get first page (no filters)
+    $response = $emailLogs->getList();
+    $data = ResponseHelper::toArray($response);
+
+    echo "Total count: " . $data['total_count'] . PHP_EOL;
+    foreach ($data['messages'] as $msg) {
+        echo "  - " . $msg['message_id'] . " | " . $msg['status'] . " | " . ($msg['subject'] ?? '') . PHP_EOL;
+    }
+
+    // Optional: filter by date range (last 2 days), recipient, categories – using the filters model
+    $sentBefore = (new DateTimeImmutable('now', new DateTimeZone('UTC')))->format(DateTimeInterface::ATOM);
+    $sentAfter = (new DateTimeImmutable('-2 days', new DateTimeZone('UTC')))->format(DateTimeInterface::ATOM);
+    $filters = EmailLogsListFilters::create(
+        $sentAfter,
+        $sentBefore,
+        [
+            'subject' => FilterCriterion::withoutValue(EmailLogsFilterOperator::NOT_EMPTY),
+            'to' => FilterCriterion::withValue(EmailLogsFilterOperator::CI_EQUAL, 'recipient@example.com'),
+            'category' => FilterCriterion::withValue(EmailLogsFilterOperator::EQUAL, ['Welcome Email', 'Order Confirmation']),
+        ]
+    );
+    $response = $emailLogs->getList($filters);
+    $data = ResponseHelper::toArray($response);
+
+    // Next page (use next_page_cursor from previous response)
+    $cursor = $data['next_page_cursor'] ?? null;
+    if ($cursor !== null) {
+        $response = $emailLogs->getList($filters, $cursor);
+        $data = ResponseHelper::toArray($response);
+    }
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Get a single email log message by ID.
+ *
+ * GET https://mailtrap.io/api/accounts/{account_id}/email_logs/{sending_message_id}
+ */
+try {
+    $listResponse = $emailLogs->getList();
+    $listData = ResponseHelper::toArray($listResponse);
+    $messageId = isset($listData['messages'][0]) ? $listData['messages'][0]['message_id'] : null;
+
+    if ($messageId !== null) {
+        $response = $emailLogs->getMessage($messageId);
+        $message = ResponseHelper::toArray($response);
+
+        echo "Message: " . $message['message_id'] . PHP_EOL;
+        echo "Status: " . $message['status'] . PHP_EOL;
+        echo "Subject: " . ($message['subject'] ?? '') . PHP_EOL;
+        echo "Events: " . count($message['events'] ?? []) . PHP_EOL;
+    } else {
+        echo "No messages in the list." . PHP_EOL;
+    }
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}

--- a/examples/sending/minimal.php
+++ b/examples/sending/minimal.php
@@ -5,7 +5,7 @@ use Mailtrap\MailtrapClient;
 use Mailtrap\Mime\MailtrapEmail;
 use Symfony\Component\Mime\Address;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 
 /**

--- a/examples/sending/suppressions.php
+++ b/examples/sending/suppressions.php
@@ -6,7 +6,7 @@ use Mailtrap\Config;
 use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapSendingClient;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 $accountId = $_ENV['MAILTRAP_ACCOUNT_ID'];
 $config = new Config($_ENV['MAILTRAP_API_KEY']); // Your API token from https://mailtrap.io/api-tokens

--- a/examples/sending/template.php
+++ b/examples/sending/template.php
@@ -7,7 +7,7 @@ use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 
 /**

--- a/examples/templates/all.php
+++ b/examples/templates/all.php
@@ -7,7 +7,7 @@ use Mailtrap\DTO\Request\EmailTemplate;
 use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapGeneralClient;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 $accountId = $_ENV['MAILTRAP_ACCOUNT_ID'];
 $config = new Config($_ENV['MAILTRAP_API_KEY']); // Your API token from https://mailtrap.io/api-tokens

--- a/examples/testing/attachments.php
+++ b/examples/testing/attachments.php
@@ -4,7 +4,7 @@ use Mailtrap\Config;
 use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapSandboxClient;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 $accountId = $_ENV['MAILTRAP_ACCOUNT_ID'];
 $inboxId = $_ENV['MAILTRAP_INBOX_ID'];

--- a/examples/testing/inboxes.php
+++ b/examples/testing/inboxes.php
@@ -5,7 +5,7 @@ use Mailtrap\DTO\Request\Inbox;
 use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapSandboxClient;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 $accountId = $_ENV['MAILTRAP_ACCOUNT_ID'];
 $config = new Config($_ENV['MAILTRAP_API_KEY']); #your API token from here https://mailtrap.io/api-tokens

--- a/examples/testing/messages.php
+++ b/examples/testing/messages.php
@@ -4,7 +4,7 @@ use Mailtrap\Config;
 use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapSandboxClient;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 // your API token from here https://mailtrap.io/api-tokens
 $accountId = $_ENV['MAILTRAP_ACCOUNT_ID'];

--- a/examples/testing/projects.php
+++ b/examples/testing/projects.php
@@ -4,7 +4,7 @@ use Mailtrap\Config;
 use Mailtrap\Helper\ResponseHelper;
 use Mailtrap\MailtrapSandboxClient;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 $accountId = $_ENV['MAILTRAP_ACCOUNT_ID'];
 $config = new Config($_ENV['MAILTRAP_API_KEY']); #your API token from here https://mailtrap.io/api-tokens

--- a/examples/testing/send-mail.php
+++ b/examples/testing/send-mail.php
@@ -6,7 +6,7 @@ use Mailtrap\Mime\MailtrapEmail;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 
 /**

--- a/examples/testing/template.php
+++ b/examples/testing/template.php
@@ -6,7 +6,7 @@ use Mailtrap\Mime\MailtrapEmail;
 use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Header\UnstructuredHeader;
 
-require __DIR__ . '/../vendor/autoload.php';
+require __DIR__ . '/../../vendor/autoload.php';
 
 
 /**

--- a/src/Api/Sending/EmailLogs.php
+++ b/src/Api/Sending/EmailLogs.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\Api\Sending;
+
+use Mailtrap\Api\AbstractApi;
+use Mailtrap\ConfigInterface;
+use Mailtrap\DTO\Request\EmailLogs\EmailLogsListFilters;
+use Mailtrap\Exception\InvalidArgumentException;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Email Logs API.
+ *
+ * List and retrieve email sending logs for the account.
+ * @see https://mailtrap.io/docs/api/sending/email-logs
+ */
+class EmailLogs extends AbstractApi implements SendingInterface
+{
+    public function __construct(ConfigInterface $config, private int $accountId)
+    {
+        parent::__construct($config);
+    }
+
+    /**
+     * List email logs (paginated).
+     *
+     * Returns a paginated list of email logs for the account. Results are restricted to sending domains
+     * the authenticated token has access to. Invalid or unknown filters are ignored.
+     * Results are ordered by sent_at descending.
+     *
+     * @param array<string, mixed>|EmailLogsListFilters $filters Filter criteria: either an EmailLogsListFilters instance
+     *                                                           or a raw array (deep object). Array keys: sent_after,
+     *                                                           sent_before, to, from, subject, status, events,
+     *                                                           clicks_count, opens_count, client_ip, sending_ip,
+     *                                                           email_service_provider_response, email_service_provider,
+     *                                                           recipient_mx, category, sending_domain_id, sending_stream.
+     * @param string|null $searchAfter Cursor for the next page (message_id UUID from previous response next_page_cursor).
+     * @return ResponseInterface 200 with body: { messages: array, total_count: int, next_page_cursor: string|null }
+     */
+    public function getList(array|EmailLogsListFilters $filters = [], ?string $searchAfter = null): ResponseInterface
+    {
+        $params = [];
+        if ($searchAfter !== null && $searchAfter !== '') {
+            $params['search_after'] = $searchAfter;
+        }
+        $filterArray = $filters instanceof EmailLogsListFilters ? $filters->toArray() : $filters;
+        if ($filterArray !== []) {
+            $params['filters'] = $filterArray;
+        }
+
+        return $this->handleResponse(
+            $this->httpGet($this->getBasePath(), $params)
+        );
+    }
+
+    /**
+     * Get a single email log message by ID.
+     *
+     * Returns message details including events. Message must belong to the account and a sending domain
+     * the token can access.
+     *
+     * @param string $sendingMessageId Message UUID (sending_message_id).
+     * @return ResponseInterface 200 with SendingMessage body (message_id, status, subject, from, to, sent_at, events, etc.)
+     */
+    public function getMessage(string $sendingMessageId): ResponseInterface
+    {
+        if (trim($sendingMessageId) === '') {
+            throw new InvalidArgumentException('sending_message_id must not be empty.');
+        }
+
+        return $this->handleResponse(
+            $this->httpGet(
+                sprintf('%s/%s', $this->getBasePath(), $sendingMessageId)
+            )
+        );
+    }
+
+    private function getBasePath(): string
+    {
+        return sprintf('%s/api/accounts/%s/email_logs', $this->getHost(), $this->accountId);
+    }
+}

--- a/src/DTO/Request/EmailLogs/EmailLogsFilterOperator.php
+++ b/src/DTO/Request/EmailLogs/EmailLogsFilterOperator.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\DTO\Request\EmailLogs;
+
+/**
+ * All supported operators for Email Logs list filters.
+ * Use with FilterCriterion::withValue() or ::withoutValue().
+ *
+ * Operator usage by filter field:
+ * - to, from, email_service_provider_response, recipient_mx: CI_* (case-insensitive string)
+ * - subject: CI_* or EMPTY / NOT_EMPTY (use withoutValue for empty/not_empty)
+ * - status: EQUAL, NOT_EQUAL — value: EmailLogsFilterValue::STATUS_*
+ * - events: INCLUDE_EVENT, NOT_INCLUDE_EVENT — value: EmailLogsFilterValue::EVENT_*
+ * - clicks_count, opens_count: EQUAL, GREATER_THAN, LESS_THAN — value: int
+ * - client_ip, sending_ip: EQUAL, NOT_EQUAL, CONTAIN, NOT_CONTAIN
+ * - email_service_provider, category: EQUAL, NOT_EQUAL — value: string or array
+ * - sending_domain_id: EQUAL, NOT_EQUAL — value: int or int[]
+ * - sending_stream: EQUAL, NOT_EQUAL — value: EmailLogsFilterValue::STREAM_*
+ */
+final class EmailLogsFilterOperator
+{
+    /** Case-insensitive equal / not equal / contain / not contain (to, from, subject, email_service_provider_response, recipient_mx) */
+    public const CI_EQUAL = 'ci_equal';
+    public const CI_NOT_EQUAL = 'ci_not_equal';
+    public const CI_CONTAIN = 'ci_contain';
+    public const CI_NOT_CONTAIN = 'ci_not_contain';
+
+    /** Subject only: has no value — use FilterCriterion::withoutValue() */
+    public const EMPTY = 'empty';
+    public const NOT_EMPTY = 'not_empty';
+
+    /** Equal / not equal (status, category, email_service_provider, sending_domain_id, sending_stream) */
+    public const EQUAL = 'equal';
+    public const NOT_EQUAL = 'not_equal';
+
+    /** Events only */
+    public const INCLUDE_EVENT = 'include_event';
+    public const NOT_INCLUDE_EVENT = 'not_include_event';
+
+    /** Numeric (clicks_count, opens_count) */
+    public const GREATER_THAN = 'greater_than';
+    public const LESS_THAN = 'less_than';
+
+    /** client_ip, sending_ip */
+    public const CONTAIN = 'contain';
+    public const NOT_CONTAIN = 'not_contain';
+
+    private function __construct()
+    {
+    }
+}

--- a/src/DTO/Request/EmailLogs/EmailLogsFilterValue.php
+++ b/src/DTO/Request/EmailLogs/EmailLogsFilterValue.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\DTO\Request\EmailLogs;
+
+/**
+ * All supported value constants for Email Logs list filters where the API accepts a fixed set.
+ * Use with FilterCriterion::withValue() and the appropriate operator (e.g. EmailLogsFilterOperator::EQUAL).
+ */
+final class EmailLogsFilterValue
+{
+    /** status filter */
+    public const STATUS_DELIVERED = 'delivered';
+    public const STATUS_NOT_DELIVERED = 'not_delivered';
+    public const STATUS_ENQUEUED = 'enqueued';
+    public const STATUS_OPTED_OUT = 'opted_out';
+
+    /** events filter */
+    public const EVENT_DELIVERY = 'delivery';
+    public const EVENT_OPEN = 'open';
+    public const EVENT_CLICK = 'click';
+    public const EVENT_BOUNCE = 'bounce';
+    public const EVENT_SPAM = 'spam';
+    public const EVENT_UNSUBSCRIBE = 'unsubscribe';
+    public const EVENT_SOFT_BOUNCE = 'soft_bounce';
+    public const EVENT_REJECT = 'reject';
+    public const EVENT_SUSPENSION = 'suspension';
+
+    /** sending_stream filter */
+    public const STREAM_TRANSACTIONAL = 'transactional';
+    public const STREAM_BULK = 'bulk';
+
+    private function __construct()
+    {
+    }
+}

--- a/src/DTO/Request/EmailLogs/EmailLogsListFilters.php
+++ b/src/DTO/Request/EmailLogs/EmailLogsListFilters.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\DTO\Request\EmailLogs;
+
+use Mailtrap\DTO\Request\RequestInterface;
+
+/**
+ * Email Logs list filters (date range + named criteria).
+ * Use with EmailLogs::getList(). Criteria keys: to, from, subject, status, events,
+ * clicks_count, opens_count, client_ip, sending_ip, email_service_provider_response,
+ * email_service_provider, recipient_mx, category, sending_domain_id, sending_stream.
+ * Use EmailLogsFilterOperator and EmailLogsFilterValue when building FilterCriterion instances.
+ */
+final class EmailLogsListFilters implements RequestInterface
+{
+    private const VALID_CRITERIA_KEYS = [
+        'to',
+        'from',
+        'subject',
+        'status',
+        'events',
+        'clicks_count',
+        'opens_count',
+        'client_ip',
+        'sending_ip',
+        'email_service_provider_response',
+        'email_service_provider',
+        'recipient_mx',
+        'category',
+        'sending_domain_id',
+        'sending_stream',
+    ];
+
+    /**
+     * @param string|null $sentAfter ISO 8601 datetime (start of sent-at range)
+     * @param string|null $sentBefore ISO 8601 datetime (end of sent-at range)
+     * @param array<string, FilterCriterion> $criteria Map of filter name => FilterCriterion (e.g. 'to' => FilterCriterion::withValue('ci_equal', 'a@b.com'))
+     */
+    public function __construct(
+        private ?string $sentAfter = null,
+        private ?string $sentBefore = null,
+        private array $criteria = []
+    ) {
+    }
+
+    public static function create(
+        ?string $sentAfter = null,
+        ?string $sentBefore = null,
+        array $criteria = []
+    ): self {
+        return new self($sentAfter, $sentBefore, $criteria);
+    }
+
+    public function withSentAfter(string $iso8601): self
+    {
+        return new self($iso8601, $this->sentBefore, $this->criteria);
+    }
+
+    public function withSentBefore(string $iso8601): self
+    {
+        return new self($this->sentAfter, $iso8601, $this->criteria);
+    }
+
+    public function withCriterion(string $name, FilterCriterion $criterion): self
+    {
+        $criteria = $this->criteria;
+        $criteria[$name] = $criterion;
+
+        return new self($this->sentAfter, $this->sentBefore, $criteria);
+    }
+
+    public function toArray(): array
+    {
+        $result = [];
+        if ($this->sentAfter !== null && $this->sentAfter !== '') {
+            $result['sent_after'] = $this->sentAfter;
+        }
+        if ($this->sentBefore !== null && $this->sentBefore !== '') {
+            $result['sent_before'] = $this->sentBefore;
+        }
+        foreach ($this->criteria as $name => $criterion) {
+            if (\in_array($name, self::VALID_CRITERIA_KEYS, true) && $criterion instanceof FilterCriterion) {
+                $result[$name] = $criterion->toArray();
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/DTO/Request/EmailLogs/FilterCriterion.php
+++ b/src/DTO/Request/EmailLogs/FilterCriterion.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\DTO\Request\EmailLogs;
+
+use Mailtrap\DTO\Request\RequestInterface;
+
+/**
+ * Single filter criterion for Email Logs list (operator + optional value).
+ * Use for: to, from, subject, status, events, clicks_count, opens_count,
+ * client_ip, sending_ip, email_service_provider_response, email_service_provider,
+ * recipient_mx, category, sending_domain_id, sending_stream.
+ *
+ * Use EmailLogsFilterOperator for operator constants and EmailLogsFilterValue for
+ * status, event type, and sending_stream values. For subject empty/not_empty use withoutValue().
+ */
+final class FilterCriterion implements RequestInterface
+{
+    public function __construct(
+        private string $operator,
+        private mixed $value = null
+    ) {
+    }
+
+    public static function withValue(string $operator, string|int|array $value): self
+    {
+        return new self($operator, $value);
+    }
+
+    /** For subject empty/not_empty and similar operators that have no value. */
+    public static function withoutValue(string $operator): self
+    {
+        return new self($operator, null);
+    }
+
+    public function getOperator(): string
+    {
+        return $this->operator;
+    }
+
+    public function getValue(): mixed
+    {
+        return $this->value;
+    }
+
+    public function toArray(): array
+    {
+        $result = ['operator' => $this->operator];
+        if ($this->value !== null) {
+            $result['value'] = $this->value;
+        }
+
+        return $result;
+    }
+}

--- a/src/MailtrapSendingClient.php
+++ b/src/MailtrapSendingClient.php
@@ -9,6 +9,7 @@ namespace Mailtrap;
  * @method  Api\Sending\Suppression suppressions(int $accountId)
  * @method  Api\Sending\Domain      domains(int $accountId)
  * @method  Api\Sending\Stats       stats(int $accountId)
+ * @method  Api\Sending\EmailLogs  emailLogs(int $accountId)
  *
  * Class MailtrapSendingClient
  */
@@ -19,5 +20,6 @@ final class MailtrapSendingClient extends AbstractMailtrapClient implements Emai
         'suppressions' => Api\Sending\Suppression::class,
         'domains' => Api\Sending\Domain::class,
         'stats' => Api\Sending\Stats::class,
+        'emailLogs' => Api\Sending\EmailLogs::class,
     ];
 }

--- a/tests/Api/AbstractApiTest.php
+++ b/tests/Api/AbstractApiTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\Tests\Api;
+
+use Mailtrap\Api\AbstractApi;
+use Mailtrap\Api\Sending\EmailLogs;
+use Mailtrap\Tests\MailtrapTestCase;
+use ReflectionClass;
+
+/**
+ * @covers \Mailtrap\Api\AbstractApi
+ */
+class AbstractApiTest extends MailtrapTestCase
+{
+    /**
+     * Ensures normalizeArrayParams converts numeric array indices to bracket notation in the query string,
+     * e.g. filters[category][value][]=Cat1&filters[category][value][]=Cat2, so that APIs (such as Email Logs)
+     * that expect multiple values in bracket form receive the correct format.
+     */
+    public function testNormalizeArrayParamsUsesBracketNotationForMultipleValues(): void
+    {
+        $params = [
+            'filters' => [
+                'category' => ['operator' => 'equal', 'value' => ['Cat1', 'Cat2']],
+            ],
+        ];
+        $api = new EmailLogs($this->getConfigMock(), self::FAKE_ACCOUNT_ID);
+        $reflection = new ReflectionClass(AbstractApi::class);
+        $method = $reflection->getMethod('normalizeArrayParams');
+        if (PHP_VERSION_ID < 80100) {
+            $method->setAccessible(true);
+        }
+        $queryString = $method->invoke($api, $params);
+
+        $this->assertStringNotContainsString('[0]', $queryString, 'Numeric indices must be normalized to bracket notation');
+        $this->assertStringNotContainsString('[1]', $queryString, 'Numeric indices must be normalized to bracket notation');
+        $this->assertMatchesRegularExpression(
+            '/filters%5Bcategory%5D%5Bvalue%5D%5B%5D=Cat1&filters%5Bcategory%5D%5Bvalue%5D%5B%5D=Cat2/',
+            $queryString,
+            'Query must use filters[category][value][]=Cat1&filters[category][value][]=Cat2'
+        );
+    }
+}

--- a/tests/Api/Sending/EmailLogsTest.php
+++ b/tests/Api/Sending/EmailLogsTest.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\Tests\Api\Sending;
+
+use Mailtrap\Api\AbstractApi;
+use Mailtrap\Api\Sending\EmailLogs;
+use Mailtrap\DTO\Request\EmailLogs\EmailLogsFilterOperator;
+use Mailtrap\DTO\Request\EmailLogs\EmailLogsFilterValue;
+use Mailtrap\DTO\Request\EmailLogs\EmailLogsListFilters;
+use Mailtrap\DTO\Request\EmailLogs\FilterCriterion;
+use Mailtrap\Exception\InvalidArgumentException;
+use Mailtrap\Helper\ResponseHelper;
+use Mailtrap\Tests\MailtrapTestCase;
+use Nyholm\Psr7\Response;
+
+/**
+ * @covers \Mailtrap\Api\Sending\EmailLogs
+ */
+class EmailLogsTest extends MailtrapTestCase
+{
+    private ?EmailLogs $emailLogs = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->emailLogs = $this->getMockBuilder(EmailLogs::class)
+            ->onlyMethods(['httpGet'])
+            ->setConstructorArgs([$this->getConfigMock(), self::FAKE_ACCOUNT_ID])
+            ->getMock();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->emailLogs = null;
+        parent::tearDown();
+    }
+
+    public function testGetListWithoutFilters(): void
+    {
+        $basePath = AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/email_logs';
+        $body = $this->getListResponseBody();
+
+        $this->emailLogs->expects($this->once())
+            ->method('httpGet')
+            ->with($basePath, [])
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($body)));
+
+        $response = $this->emailLogs->getList();
+        $data = ResponseHelper::toArray($response);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertArrayHasKey('messages', $data);
+        $this->assertArrayHasKey('total_count', $data);
+        $this->assertArrayHasKey('next_page_cursor', $data);
+        $this->assertSame(150, $data['total_count']);
+        $this->assertCount(2, $data['messages']);
+        $this->assertSame('a1b2c3d4-e5f6-7890-abcd-ef1234567890', $data['messages'][0]['message_id']);
+    }
+
+    public function testGetListWithFiltersAndSearchAfter(): void
+    {
+        $basePath = AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/email_logs';
+        $filters = [
+            'sent_after' => '2025-01-01T00:00:00Z',
+            'sent_before' => '2025-01-31T23:59:59Z',
+            'to' => ['operator' => 'ci_equal', 'value' => 'recipient@example.com'],
+            'sending_domain_id' => ['operator' => 'equal', 'value' => [3938, 3939]],
+        ];
+        $searchAfter = 'b2c3d4e5-f6a7-8901-bcde-f12345678901';
+        $params = [
+            'search_after' => $searchAfter,
+            'filters' => $filters,
+        ];
+        $body = $this->getListResponseBody();
+
+        $this->emailLogs->expects($this->once())
+            ->method('httpGet')
+            ->with($basePath, $params)
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($body)));
+
+        $response = $this->emailLogs->getList($filters, $searchAfter);
+        $data = ResponseHelper::toArray($response);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertArrayHasKey('messages', $data);
+    }
+
+    public function testGetListWithEmailLogsListFiltersModel(): void
+    {
+        $basePath = AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/email_logs';
+        $filters = EmailLogsListFilters::create(
+            '2025-01-01T00:00:00Z',
+            '2025-01-31T23:59:59Z',
+            [
+                'to' => FilterCriterion::withValue(EmailLogsFilterOperator::CI_EQUAL, 'recipient@example.com'),
+                'subject' => FilterCriterion::withoutValue(EmailLogsFilterOperator::NOT_EMPTY),
+                'category' => FilterCriterion::withValue(EmailLogsFilterOperator::EQUAL, ['Welcome Email', 'Order Confirmation']),
+            ]
+        );
+        $expectedParams = [
+            'filters' => $filters->toArray(),
+        ];
+        $body = $this->getListResponseBody();
+
+        $this->emailLogs->expects($this->once())
+            ->method('httpGet')
+            ->with($basePath, $expectedParams)
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($body)));
+
+        $response = $this->emailLogs->getList($filters);
+        $data = ResponseHelper::toArray($response);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertArrayHasKey('messages', $data);
+        $this->assertSame('2025-01-01T00:00:00Z', $expectedParams['filters']['sent_after']);
+        $this->assertSame(EmailLogsFilterOperator::NOT_EMPTY, $expectedParams['filters']['subject']['operator']);
+        $this->assertArrayNotHasKey('value', $expectedParams['filters']['subject']);
+    }
+
+    public function testGetListWithOperatorAndValueConstants(): void
+    {
+        $basePath = AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/email_logs';
+        $filters = EmailLogsListFilters::create(
+            null,
+            null,
+            [
+                'status' => FilterCriterion::withValue(EmailLogsFilterOperator::EQUAL, EmailLogsFilterValue::STATUS_DELIVERED),
+                'events' => FilterCriterion::withValue(EmailLogsFilterOperator::INCLUDE_EVENT, EmailLogsFilterValue::EVENT_OPEN),
+                'sending_stream' => FilterCriterion::withValue(EmailLogsFilterOperator::EQUAL, EmailLogsFilterValue::STREAM_TRANSACTIONAL),
+            ]
+        );
+        $expectedParams = ['filters' => $filters->toArray()];
+        $body = $this->getListResponseBody();
+
+        $this->emailLogs->expects($this->once())
+            ->method('httpGet')
+            ->with($basePath, $expectedParams)
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($body)));
+
+        $response = $this->emailLogs->getList($filters);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(EmailLogsFilterValue::STATUS_DELIVERED, $expectedParams['filters']['status']['value']);
+        $this->assertSame(EmailLogsFilterValue::EVENT_OPEN, $expectedParams['filters']['events']['value']);
+        $this->assertSame(EmailLogsFilterValue::STREAM_TRANSACTIONAL, $expectedParams['filters']['sending_stream']['value']);
+    }
+
+    public function testGetMessage(): void
+    {
+        $messageId = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+        $basePath = AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/email_logs/' . $messageId;
+        $body = $this->getMessageResponseBody();
+
+        $this->emailLogs->expects($this->once())
+            ->method('httpGet')
+            ->with($basePath, [])
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($body)));
+
+        $response = $this->emailLogs->getMessage($messageId);
+        $data = ResponseHelper::toArray($response);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame($messageId, $data['message_id']);
+        $this->assertSame('delivered', $data['status']);
+        $this->assertArrayHasKey('events', $data);
+    }
+
+    public function testGetMessageThrowsWhenSendingMessageIdIsEmpty(): void
+    {
+        $emailLogs = new EmailLogs($this->getConfigMock(), self::FAKE_ACCOUNT_ID);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('sending_message_id must not be empty.');
+
+        $emailLogs->getMessage('');
+    }
+
+    public function testGetMessageThrowsWhenSendingMessageIdIsWhitespaceOnly(): void
+    {
+        $emailLogs = new EmailLogs($this->getConfigMock(), self::FAKE_ACCOUNT_ID);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('sending_message_id must not be empty.');
+
+        $emailLogs->getMessage('   ');
+    }
+
+    private function getListResponseBody(): array
+    {
+        return [
+            'messages' => [
+                [
+                    'message_id' => 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+                    'status' => 'delivered',
+                    'subject' => 'Welcome to our service',
+                    'from' => 'sender@example.com',
+                    'to' => 'recipient@example.com',
+                    'sent_at' => '2025-01-15T10:30:00Z',
+                    'client_ip' => '203.0.113.42',
+                    'category' => 'Welcome Email',
+                    'custom_variables' => [],
+                    'sending_stream' => 'transactional',
+                    'sending_domain_id' => 3938,
+                    'template_id' => 100,
+                    'template_variables' => [],
+                    'opens_count' => 2,
+                    'clicks_count' => 1,
+                ],
+                [
+                    'message_id' => 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
+                    'status' => 'delivered',
+                    'subject' => 'Your order confirmation',
+                    'from' => 'orders@example.com',
+                    'to' => 'customer@example.com',
+                    'sent_at' => '2025-01-15T11:00:00Z',
+                    'client_ip' => null,
+                    'category' => 'Order Confirmation',
+                    'custom_variables' => ['order_id' => '12345'],
+                    'sending_stream' => 'transactional',
+                    'sending_domain_id' => 3938,
+                    'template_id' => null,
+                    'template_variables' => [],
+                    'opens_count' => 0,
+                    'clicks_count' => 0,
+                ],
+            ],
+            'total_count' => 150,
+            'next_page_cursor' => 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
+        ];
+    }
+
+    private function getMessageResponseBody(): array
+    {
+        return [
+            'message_id' => 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+            'status' => 'delivered',
+            'subject' => 'Welcome to our service',
+            'from' => 'sender@example.com',
+            'to' => 'recipient@example.com',
+            'sent_at' => '2025-01-15T10:30:00Z',
+            'client_ip' => '203.0.113.42',
+            'category' => 'Welcome Email',
+            'custom_variables' => [],
+            'sending_stream' => 'transactional',
+            'sending_domain_id' => 3938,
+            'template_id' => 100,
+            'template_variables' => [],
+            'opens_count' => 2,
+            'clicks_count' => 1,
+            'raw_message_url' => 'https://storage.example.com/signed/eml/a1b2c3d4-e5f6-7890-abcd-ef1234567890?token=...',
+            'events' => [
+                [
+                    'event_type' => 'click',
+                    'created_at' => '2025-01-15T10:35:00Z',
+                    'details' => [
+                        'click_url' => 'https://example.com/track/click/abc123',
+                        'web_ip_address' => '198.51.100.50',
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/tests/MailtrapSendingClientTest.php
+++ b/tests/MailtrapSendingClientTest.php
@@ -30,7 +30,7 @@ class MailtrapSendingClientTest extends MailtrapClientTestCase
     {
         foreach (MailtrapSendingClient::API_MAPPING as $key => $item) {
             yield match ($key) {
-                'suppressions', 'domains', 'stats' => [new $item($this->getConfigMock(), self::FAKE_ACCOUNT_ID)],
+                'suppressions', 'domains', 'stats', 'emailLogs' => [new $item($this->getConfigMock(), self::FAKE_ACCOUNT_ID)],
                 default => [new $item($this->getConfigMock())],
             };
         }


### PR DESCRIPTION
## Changes

- Add support for Email Logs API
- Fix autoload.php path in examples

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Email Logs API: list and retrieve individual email logs with rich filtering and pagination.

* **Documentation**
  * Email Logs documented under Email API; Suppressions removed from General API; added example demonstrating listing, filtering, pagination, and fetching a message by ID.

* **Tests**
  * New tests covering Email Logs behavior and query parameter normalization.

* **Chores**
  * Updated PHP example bootstrap paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->