### PR TITLE
Change PUT to PATCH method for contacts#update action

### DIFF
--- a/src/Api/General/Contact.php
+++ b/src/Api/General/Contact.php
@@ -381,7 +381,7 @@ class Contact extends AbstractApi implements GeneralInterface
     private function updateContact(string $contactIdOrEmail, UpdateContact $contact): ResponseInterface
     {
         return $this->handleResponse(
-            $this->httpPut(
+            $this->httpPatch(
                 path: $this->getBasePath() . '/' . urlencode($contactIdOrEmail),
                 body: ['contact' => $contact->toArray()]
             )

--- a/tests/Api/General/ContactTest.php
+++ b/tests/Api/General/ContactTest.php
@@ -32,7 +32,7 @@ class ContactTest extends MailtrapTestCase
         parent::setUp();
 
         $this->contact = $this->getMockBuilder(Contact::class)
-            ->onlyMethods(['httpGet', 'httpPost', 'httpPut', 'httpPatch', 'httpDelete'])
+            ->onlyMethods(['httpGet', 'httpPost', 'httpPatch', 'httpDelete'])
             ->setConstructorArgs([$this->getConfigMock(), self::FAKE_ACCOUNT_ID])
             ->getMock();
     }
@@ -236,7 +236,7 @@ class ContactTest extends MailtrapTestCase
         $contactDTO = new UpdateContact('test@example.com', ['last_name' => 'Smith'], [3], [1, 2], true);
 
         $this->contact->expects($this->once())
-            ->method('httpPut')
+            ->method('httpPatch')
             ->with(
                 AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/' . $contactId,
                 [],
@@ -266,7 +266,7 @@ class ContactTest extends MailtrapTestCase
         $contactDTO = new UpdateContact('test@example.com', ['last_name' => 'Smith'], [3], [1, 2], true);
 
         $this->contact->expects($this->once())
-            ->method('httpPut')
+            ->method('httpPatch')
             ->with(
                 AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/' . urlencode($contactEmail),
                 [],
@@ -289,7 +289,7 @@ class ContactTest extends MailtrapTestCase
         $contactDTO = new UpdateContact($contactEmail, ['last_name' => 'Smith'], [3], [1, 2]);
 
         $this->contact->expects($this->once())
-            ->method('httpPut')
+            ->method('httpPatch')
             ->with(
                 AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/' . urlencode($contactEmail),
                 [],


### PR DESCRIPTION
## Motivation

https://github.com/mailtrap/mailtrap-php/issues/63

## Changes

- Change PUT to PATCH method for contact#update action

## How to test

- [ ] Smoke test Contact update action

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved contact update request handling to use more appropriate HTTP standards for partial resource modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->