### PR TITLE
MT-22678: Add name search filter to getAllContactLists

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Email Sandbox (Testing):
 
 Contact management:
 - Contacts CRUD & listing – [`contacts/all.php`](examples/contacts/all.php)
-- Contact lists CRUD & name search – [`contact-lists/all.php`](examples/contact-lists/all.php)
+- Contact lists CRUD – [`contact-lists/all.php`](examples/contact-lists/all.php)
 - Custom fields CRUD – [`contact-fields/all.php`](examples/contact-fields/all.php)
 - Import/Export – (no example yet) ← add in future
 - Events – (no example yet) ← add in future

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Email Sandbox (Testing):
 
 Contact management:
 - Contacts CRUD & listing – [`contacts/all.php`](examples/contacts/all.php)
-- Contact lists CRUD – [`contact-lists/all.php`](examples/contact-lists/all.php)
+- Contact lists CRUD & name search – [`contact-lists/all.php`](examples/contact-lists/all.php)
 - Custom fields CRUD – [`contact-fields/all.php`](examples/contact-fields/all.php)
 - Import/Export – (no example yet) ← add in future
 - Events – (no example yet) ← add in future

--- a/examples/contact-lists/all.php
+++ b/examples/contact-lists/all.php
@@ -31,6 +31,21 @@ try {
 
 
 /**
+ * Get all Contact Lists filtered by name (case-insensitive prefix match).
+ *
+ * GET https://mailtrap.io/api/accounts/{account_id}/contacts/lists?search=news
+ */
+try {
+    $response = $contacts->getAllContactLists('news'); // Replace 'news' with your desired name prefix
+
+    // print the response body (array)
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ',  $e->getMessage(), PHP_EOL;
+}
+
+
+/**
  * Get a specific Contact List by ID.
  *
  * GET https://mailtrap.io/api/accounts/{account_id}/contacts/lists/{list_id}

--- a/src/Api/General/Contact.php
+++ b/src/Api/General/Contact.php
@@ -27,12 +27,18 @@ class Contact extends AbstractApi implements GeneralInterface
     /**
      * Get all Contact Lists.
      *
+     * @param string|null $search Filter contact lists by name (case-insensitive prefix match), or null to get all.
      * @return ResponseInterface
      */
-    public function getAllContactLists(): ResponseInterface
+    public function getAllContactLists(?string $search = null): ResponseInterface
     {
+        $parameters = [];
+        if ($search !== null) {
+            $parameters['search'] = $search;
+        }
+
         return $this->handleResponse(
-            $this->httpGet($this->getBasePath() . '/lists')
+            $this->httpGet($this->getBasePath() . '/lists', $parameters)
         );
     }
 

--- a/tests/Api/General/ContactTest.php
+++ b/tests/Api/General/ContactTest.php
@@ -59,6 +59,26 @@ class ContactTest extends MailtrapTestCase
         $this->assertArrayHasKey('id', $responseData[0]);
     }
 
+    public function testGetAllContactListsWithSearch(): void
+    {
+        $search = 'news';
+
+        $this->contact->expects($this->once())
+            ->method('httpGet')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/contacts/lists',
+                ['search' => $search]
+            )
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], json_encode($this->getExpectedContactLists())));
+
+        $response = $this->contact->getAllContactLists($search);
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertCount(2, $responseData);
+        $this->assertArrayHasKey('id', $responseData[0]);
+    }
+
     public function testGetContactList(): void
     {
         $contactListId = 1;


### PR DESCRIPTION
## Motivation

https://railsware.atlassian.net/browse/MT-22678

## Changes

- Add an optional `$search` argument to `Contact::getAllContactLists` — filters contact lists by name (case-insensitive prefix match), per the OpenAPI `GET /api/contacts/lists` param. Appended only when provided, so existing calls are unchanged.

## How to test

- [ ] `$contacts->getAllContactLists()` — returns all contact lists (unchanged behaviour).
- [ ] `$contacts->getAllContactLists('news')` — returns only lists whose name starts with "news" (case-insensitive).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional name-prefix filtering when retrieving contact lists.
  - Added an example demonstrating filtered contact-list retrieval and response handling.

- **Bug Fixes**
  - Improved coverage for contact-list searches, including query parameters and response validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->