### PR TITLE
MT-22401: Add Email Campaigns API

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,9 @@ Contact management:
 - Import/Export – (no example yet) ← add in future
 - Events – (no example yet) ← add in future
 
+Email marketing:
+- Email campaigns CRUD, listing, lifecycle & stats – [`email-campaigns/all.php`](examples/email-campaigns/all.php)
+
 General API:
 - Templates CRUD – [`templates/all.php`](examples/templates/all.php)
 - Billing info – [`general/billing.php`](examples/general/billing.php)

--- a/examples/README.md
+++ b/examples/README.md
@@ -57,6 +57,7 @@ Central index of runnable example scripts demonstrating Mailtrap PHP SDK feature
 | Contacts CRUD + list | [`contacts/all.php`](contacts/all.php) |
 | Contact lists CRUD | [`contact-lists/all.php`](contact-lists/all.php) |
 | Custom fields CRUD | [`contact-fields/all.php`](contact-fields/all.php) |
+| Email campaigns CRUD + list + lifecycle + stats | [`email-campaigns/all.php`](email-campaigns/all.php) |
 
 ### Templates & Domains
 

--- a/examples/email-campaigns/all.php
+++ b/examples/email-campaigns/all.php
@@ -13,7 +13,7 @@ use Mailtrap\MailtrapGeneralClient;
 
 require __DIR__ . '/../../vendor/autoload.php';
 
-$accountId = $_ENV['MAILTRAP_ACCOUNT_ID'];
+$accountId = (int) $_ENV['MAILTRAP_ACCOUNT_ID'];
 $config = new Config($_ENV['MAILTRAP_API_KEY']); // your API token from https://mailtrap.io/api-tokens
 $emailCampaigns = (new MailtrapGeneralClient($config))->emailCampaigns($accountId);
 
@@ -34,30 +34,15 @@ try {
 }
 
 /**
- * Get a single email campaign by ID (wrapped in `data`).
- *
- * GET https://mailtrap.io/api/email_campaigns/{email_campaign_id}
- */
-try {
-    $emailCampaignId = 4567; // replace with a valid campaign ID
-
-    $response = $emailCampaigns->getEmailCampaign($emailCampaignId);
-
-    var_dump(ResponseHelper::toArray($response));
-} catch (Exception $e) {
-    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
-}
-
-/**
  * Create a new email campaign in the `draft` state (wrapped in `data`).
- * `name`, `mailsend_domain_id` (a UUID), `from_local_part` and a template `subject` are required.
+ * `name`, `domain_id`, `from_local_part` and a template `subject` are required.
  *
  * POST https://mailtrap.io/api/email_campaigns
  */
 try {
     $response = $emailCampaigns->createEmailCampaign(new CreateEmailCampaign(
         name: 'Spring Sale',
-        mailsendDomainId: $_ENV['MAILTRAP_DOMAIN_ID'] ?? 'd2313359-acb4-4b87-bce6-f5774f6a1e37',
+        domainId: (int) $_ENV['MAILTRAP_DOMAIN_ID'], // set this environment variable with your sending domain ID
         fromLocalPart: 'news',
         templateAttributes: new TemplateAttributes(subject: 'Spring is here — 30% off'),
         fromDisplayName: 'Acme Marketing',
@@ -67,6 +52,24 @@ try {
             domain: 'acme.com',
         ),
     ));
+
+    $emailCampaign = ResponseHelper::toArray($response);
+    $emailCampaignId = $emailCampaign['data']['id']; // reused by all the examples below
+
+    var_dump($emailCampaign);
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+
+    exit(1); // the examples below operate on the campaign created here
+}
+
+/**
+ * Get a single email campaign by ID (wrapped in `data`).
+ *
+ * GET https://mailtrap.io/api/email_campaigns/{email_campaign_id}
+ */
+try {
+    $response = $emailCampaigns->getEmailCampaign($emailCampaignId);
 
     var_dump(ResponseHelper::toArray($response));
 } catch (Exception $e) {
@@ -81,8 +84,6 @@ try {
  * PATCH https://mailtrap.io/api/email_campaigns/{email_campaign_id}
  */
 try {
-    $emailCampaignId = 4567; // replace with a valid campaign ID
-
     $response = $emailCampaigns->updateEmailCampaign(
         $emailCampaignId,
         new UpdateEmailCampaign(
@@ -95,8 +96,8 @@ try {
                     . '<p><a href="__unsubscribe_url__">Unsubscribe</a></p></body></html>',
                 mergeTags: ['first_name'],
             ),
-            contactListIds: [55, 56],
-            contactSegmentIds: [12],
+            contactListIds: [55, 56], // replace with your contact list IDs
+            contactSegmentIds: [12], // replace with your contact segment IDs
         )
     );
 
@@ -113,11 +114,38 @@ try {
  * POST https://mailtrap.io/api/email_campaigns/{email_campaign_id}/schedule
  */
 try {
-    $emailCampaignId = 4567; // replace with a valid campaign ID
-
     $response = $emailCampaigns->scheduleEmailCampaign(
         $emailCampaignId,
         new DateTimeImmutable('+1 week', new DateTimeZone('UTC'))
+    );
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Reset a `scheduled` campaign back to the `draft` state.
+ *
+ * POST https://mailtrap.io/api/email_campaigns/{email_campaign_id}/reset
+ */
+try {
+    $response = $emailCampaigns->resetEmailCampaign($emailCampaignId);
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Schedule the campaign again so the cancellation below acts on a `scheduled` campaign.
+ *
+ * POST https://mailtrap.io/api/email_campaigns/{email_campaign_id}/schedule
+ */
+try {
+    $response = $emailCampaigns->scheduleEmailCampaign(
+        $emailCampaignId,
+        new DateTimeImmutable('+1 day', new DateTimeZone('UTC'))
     );
 
     var_dump(ResponseHelper::toArray($response));
@@ -131,8 +159,6 @@ try {
  * POST https://mailtrap.io/api/email_campaigns/{email_campaign_id}/cancel
  */
 try {
-    $emailCampaignId = 4567; // replace with a valid campaign ID
-
     $response = $emailCampaigns->cancelEmailCampaign($emailCampaignId);
 
     var_dump(ResponseHelper::toArray($response));
@@ -146,8 +172,6 @@ try {
  * POST https://mailtrap.io/api/email_campaigns/{email_campaign_id}/start
  */
 try {
-    $emailCampaignId = 4567; // replace with a valid campaign ID
-
     $response = $emailCampaigns->startEmailCampaign($emailCampaignId);
 
     var_dump(ResponseHelper::toArray($response));
@@ -161,24 +185,7 @@ try {
  * POST https://mailtrap.io/api/email_campaigns/{email_campaign_id}/terminate
  */
 try {
-    $emailCampaignId = 4567; // replace with a valid campaign ID
-
     $response = $emailCampaigns->terminateEmailCampaign($emailCampaignId);
-
-    var_dump(ResponseHelper::toArray($response));
-} catch (Exception $e) {
-    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
-}
-
-/**
- * Reset a `scheduled` campaign back to the `draft` state.
- *
- * POST https://mailtrap.io/api/email_campaigns/{email_campaign_id}/reset
- */
-try {
-    $emailCampaignId = 4567; // replace with a valid campaign ID
-
-    $response = $emailCampaigns->resetEmailCampaign($emailCampaignId);
 
     var_dump(ResponseHelper::toArray($response));
 } catch (Exception $e) {
@@ -193,12 +200,10 @@ try {
  * GET https://mailtrap.io/api/email_campaigns/{email_campaign_id}/stats
  */
 try {
-    $emailCampaignId = 4567; // replace with a valid campaign ID
-
     $response = $emailCampaigns->getEmailCampaignStats(
         $emailCampaignId,
-        startDate: '2026-05-01',
-        endDate: '2026-05-31'
+        startDate: (new DateTimeImmutable('-30 days'))->format('Y-m-d'),
+        endDate: (new DateTimeImmutable('today'))->format('Y-m-d')
     );
 
     var_dump(ResponseHelper::toArray($response));
@@ -213,8 +218,6 @@ try {
  * DELETE https://mailtrap.io/api/email_campaigns/{email_campaign_id}
  */
 try {
-    $emailCampaignId = 4567; // replace with a valid campaign ID
-
     $response = $emailCampaigns->deleteEmailCampaign($emailCampaignId);
 
     var_dump($response->getStatusCode()); // 204

--- a/examples/email-campaigns/all.php
+++ b/examples/email-campaigns/all.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+use Mailtrap\Config;
+use Mailtrap\DTO\Request\EmailCampaign\CreateEmailCampaign;
+use Mailtrap\DTO\Request\EmailCampaign\EmailCampaignInterface;
+use Mailtrap\DTO\Request\EmailCampaign\ReplyTo;
+use Mailtrap\DTO\Request\EmailCampaign\TemplateAttributes;
+use Mailtrap\DTO\Request\EmailCampaign\UpdateEmailCampaign;
+use Mailtrap\Helper\ResponseHelper;
+use Mailtrap\MailtrapGeneralClient;
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$accountId = $_ENV['MAILTRAP_ACCOUNT_ID'];
+$config = new Config($_ENV['MAILTRAP_API_KEY']); // your API token from https://mailtrap.io/api-tokens
+$emailCampaigns = (new MailtrapGeneralClient($config))->emailCampaigns($accountId);
+
+/**
+ * Get a paginated list of email campaigns (newest first).
+ * Optional filters: $perPage (max 100, default 50), $search (name filter), $token (page number).
+ *
+ * The response is wrapped in `{ data: [...], pagination }`.
+ *
+ * GET https://mailtrap.io/api/email_campaigns
+ */
+try {
+    $response = $emailCampaigns->getEmailCampaigns(perPage: 50, search: 'Spring', token: 1);
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Get a single email campaign by ID (wrapped in `data`).
+ *
+ * GET https://mailtrap.io/api/email_campaigns/{email_campaign_id}
+ */
+try {
+    $emailCampaignId = 4567; // replace with a valid campaign ID
+
+    $response = $emailCampaigns->getEmailCampaign($emailCampaignId);
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Create a new email campaign in the `draft` state (wrapped in `data`).
+ * `name`, `mailsend_domain_id` (a UUID), `from_local_part` and a template `subject` are required.
+ *
+ * POST https://mailtrap.io/api/email_campaigns
+ */
+try {
+    $response = $emailCampaigns->createEmailCampaign(new CreateEmailCampaign(
+        name: 'Spring Sale',
+        mailsendDomainId: $_ENV['MAILTRAP_DOMAIN_ID'] ?? 'd2313359-acb4-4b87-bce6-f5774f6a1e37',
+        fromLocalPart: 'news',
+        templateAttributes: new TemplateAttributes(subject: 'Spring is here — 30% off'),
+        fromDisplayName: 'Acme Marketing',
+        replyTo: new ReplyTo(
+            displayName: 'Acme Support',
+            localPart: 'support',
+            domain: 'acme.com',
+        ),
+    ));
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Update an existing `draft` email campaign (PATCH — only provided attributes change).
+ * Add the design and pick the audience; `contact_list_ids`/`contact_segment_ids` are the
+ * full set of included lists/segments (`[]` clears them).
+ *
+ * PATCH https://mailtrap.io/api/email_campaigns/{email_campaign_id}
+ */
+try {
+    $emailCampaignId = 4567; // replace with a valid campaign ID
+
+    $response = $emailCampaigns->updateEmailCampaign(
+        $emailCampaignId,
+        new UpdateEmailCampaign(
+            name: 'Spring Sale (updated)',
+            deliveryMode: EmailCampaignInterface::DELIVERY_MODE_GRADUAL,
+            deliveryOptions: ['emails_per_hour' => 1000],
+            templateAttributes: new TemplateAttributes(
+                subject: 'New subject',
+                bodyHtml: '<html><body><h1>Hi {{first_name}}!</h1>'
+                    . '<p><a href="__unsubscribe_url__">Unsubscribe</a></p></body></html>',
+                mergeTags: ['first_name'],
+            ),
+            contactListIds: [55, 56],
+            contactSegmentIds: [12],
+        )
+    );
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Schedule a `draft` campaign to start sending at a future time (no more than 1 month ahead).
+ * Accepts an ISO 8601 string or a \DateTimeInterface. The scheduled time is reported back in
+ * `current_state_metadata.scheduled_at`.
+ *
+ * POST https://mailtrap.io/api/email_campaigns/{email_campaign_id}/schedule
+ */
+try {
+    $emailCampaignId = 4567; // replace with a valid campaign ID
+
+    $response = $emailCampaigns->scheduleEmailCampaign(
+        $emailCampaignId,
+        new DateTimeImmutable('+1 week', new DateTimeZone('UTC'))
+    );
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Cancel a `scheduled` campaign, returning it to the `draft` state.
+ *
+ * POST https://mailtrap.io/api/email_campaigns/{email_campaign_id}/cancel
+ */
+try {
+    $emailCampaignId = 4567; // replace with a valid campaign ID
+
+    $response = $emailCampaigns->cancelEmailCampaign($emailCampaignId);
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Start sending a `draft` campaign immediately.
+ *
+ * POST https://mailtrap.io/api/email_campaigns/{email_campaign_id}/start
+ */
+try {
+    $emailCampaignId = 4567; // replace with a valid campaign ID
+
+    $response = $emailCampaigns->startEmailCampaign($emailCampaignId);
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Terminate a campaign that is currently sending (`started`, `queued`, or `paused`).
+ *
+ * POST https://mailtrap.io/api/email_campaigns/{email_campaign_id}/terminate
+ */
+try {
+    $emailCampaignId = 4567; // replace with a valid campaign ID
+
+    $response = $emailCampaigns->terminateEmailCampaign($emailCampaignId);
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Reset a `scheduled` campaign back to the `draft` state.
+ *
+ * POST https://mailtrap.io/api/email_campaigns/{email_campaign_id}/reset
+ */
+try {
+    $emailCampaignId = 4567; // replace with a valid campaign ID
+
+    $response = $emailCampaigns->resetEmailCampaign($emailCampaignId);
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Get aggregated performance statistics for a campaign (wrapped in `data`).
+ * All counts and rates are `0` when the campaign has never been started. Use the optional
+ * `YYYY-MM-DD` date parameters to narrow the aggregation window.
+ *
+ * GET https://mailtrap.io/api/email_campaigns/{email_campaign_id}/stats
+ */
+try {
+    $emailCampaignId = 4567; // replace with a valid campaign ID
+
+    $response = $emailCampaigns->getEmailCampaignStats(
+        $emailCampaignId,
+        startDate: '2026-05-01',
+        endDate: '2026-05-31'
+    );
+
+    var_dump(ResponseHelper::toArray($response));
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}
+
+/**
+ * Delete an email campaign. The campaign must not be in a sending state.
+ * Returns `204 No Content` with an empty body.
+ *
+ * DELETE https://mailtrap.io/api/email_campaigns/{email_campaign_id}
+ */
+try {
+    $emailCampaignId = 4567; // replace with a valid campaign ID
+
+    $response = $emailCampaigns->deleteEmailCampaign($emailCampaignId);
+
+    var_dump($response->getStatusCode()); // 204
+} catch (Exception $e) {
+    echo 'Caught exception: ', $e->getMessage(), PHP_EOL;
+}

--- a/src/Api/General/EmailCampaign.php
+++ b/src/Api/General/EmailCampaign.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\Api\General;
+
+use Mailtrap\Api\AbstractApi;
+use Mailtrap\ConfigInterface;
+use Mailtrap\DTO\Request\EmailCampaign\CreateEmailCampaign;
+use Mailtrap\DTO\Request\EmailCampaign\UpdateEmailCampaign;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Class EmailCampaign
+ *
+ * Email Campaigns API. Note: this resource is token-scoped — the account is resolved from
+ * the API token, so the path is the bare `/api/email_campaigns` (NOT account-scoped). The
+ * account id is accepted for consistency with the other General API resources only.
+ */
+class EmailCampaign extends AbstractApi implements GeneralInterface
+{
+    public function __construct(ConfigInterface $config, private int $accountId)
+    {
+        parent::__construct($config);
+    }
+
+    /**
+     * Get a paginated list of email campaigns, newest first.
+     * The response is wrapped in `{ data: [...], pagination }`.
+     *
+     * @param int|null    $perPage Number of campaigns per page (max 100, default 50)
+     * @param string|null $search  Filter campaigns by name
+     * @param int|null    $token   Page number to retrieve (page-token pagination, default 1)
+     *
+     * @return ResponseInterface
+     */
+    public function getEmailCampaigns(
+        ?int $perPage = null,
+        ?string $search = null,
+        ?int $token = null
+    ): ResponseInterface {
+        $parameters = [];
+
+        if ($perPage !== null) {
+            $parameters['per_page'] = $perPage;
+        }
+
+        if ($search !== null) {
+            $parameters['search'] = $search;
+        }
+
+        if ($token !== null) {
+            $parameters['token'] = $token;
+        }
+
+        return $this->handleResponse(
+            $this->httpGet($this->getBasePath(), $parameters)
+        );
+    }
+
+    /**
+     * Get an email campaign by ID. The campaign is wrapped in `data`.
+     *
+     * @param int $emailCampaignId
+     * @return ResponseInterface
+     */
+    public function getEmailCampaign(int $emailCampaignId): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpGet($this->getBasePath() . '/' . $emailCampaignId)
+        );
+    }
+
+    /**
+     * Create a new email campaign in the `draft` state. The campaign is wrapped in `data`.
+     *
+     * @param CreateEmailCampaign $emailCampaign
+     * @return ResponseInterface
+     */
+    public function createEmailCampaign(CreateEmailCampaign $emailCampaign): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpPost(
+                path: $this->getBasePath(),
+                body: $emailCampaign->toArray()
+            )
+        );
+    }
+
+    /**
+     * Update an existing `draft` email campaign (PATCH, partial). The campaign is wrapped
+     * in `data`.
+     *
+     * @param int                 $emailCampaignId
+     * @param UpdateEmailCampaign $emailCampaign
+     * @return ResponseInterface
+     */
+    public function updateEmailCampaign(int $emailCampaignId, UpdateEmailCampaign $emailCampaign): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpPatch(
+                path: $this->getBasePath() . '/' . $emailCampaignId,
+                body: $emailCampaign->toArray()
+            )
+        );
+    }
+
+    /**
+     * Delete an email campaign. The campaign must not be in a sending state.
+     * Returns `204 No Content` with an empty body.
+     *
+     * @param int $emailCampaignId
+     * @return ResponseInterface
+     */
+    public function deleteEmailCampaign(int $emailCampaignId): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpDelete($this->getBasePath() . '/' . $emailCampaignId)
+        );
+    }
+
+    /**
+     * Start sending a `draft` email campaign immediately. The campaign is wrapped in `data`.
+     *
+     * @param int $emailCampaignId
+     * @return ResponseInterface
+     */
+    public function startEmailCampaign(int $emailCampaignId): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpPost($this->getBasePath() . '/' . $emailCampaignId . '/start')
+        );
+    }
+
+    /**
+     * Schedule a `draft` email campaign to start sending at a future time (no more than
+     * 1 month ahead). The scheduled time is reported back in
+     * `current_state_metadata.scheduled_at`. The campaign is wrapped in `data`.
+     *
+     * @param int                       $emailCampaignId
+     * @param string|\DateTimeInterface $datetime When to send the campaign (ISO 8601)
+     * @return ResponseInterface
+     */
+    public function scheduleEmailCampaign(int $emailCampaignId, string|\DateTimeInterface $datetime): ResponseInterface
+    {
+        if ($datetime instanceof \DateTimeInterface) {
+            $datetime = $datetime->format(\DateTimeInterface::ATOM);
+        }
+
+        return $this->handleResponse(
+            $this->httpPost(
+                path: $this->getBasePath() . '/' . $emailCampaignId . '/schedule',
+                body: ['datetime' => $datetime]
+            )
+        );
+    }
+
+    /**
+     * Cancel a `scheduled` email campaign, returning it to the `draft` state. The campaign
+     * is wrapped in `data`.
+     *
+     * @param int $emailCampaignId
+     * @return ResponseInterface
+     */
+    public function cancelEmailCampaign(int $emailCampaignId): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpPost($this->getBasePath() . '/' . $emailCampaignId . '/cancel')
+        );
+    }
+
+    /**
+     * Terminate an email campaign that is currently sending (`started`, `queued`, or
+     * `paused`), aborting the in-flight send. The campaign is wrapped in `data`.
+     *
+     * @param int $emailCampaignId
+     * @return ResponseInterface
+     */
+    public function terminateEmailCampaign(int $emailCampaignId): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpPost($this->getBasePath() . '/' . $emailCampaignId . '/terminate')
+        );
+    }
+
+    /**
+     * Reset a `scheduled` email campaign back to the `draft` state. The campaign is wrapped
+     * in `data`.
+     *
+     * @param int $emailCampaignId
+     * @return ResponseInterface
+     */
+    public function resetEmailCampaign(int $emailCampaignId): ResponseInterface
+    {
+        return $this->handleResponse(
+            $this->httpPost($this->getBasePath() . '/' . $emailCampaignId . '/reset')
+        );
+    }
+
+    /**
+     * Get aggregated performance statistics for an email campaign, wrapped in `data`.
+     * By default stats cover the whole period since the campaign was last started; narrow
+     * the window with the optional date parameters.
+     *
+     * @param int         $emailCampaignId
+     * @param string|null $startDate Start of the aggregation window (inclusive), `YYYY-MM-DD`
+     * @param string|null $endDate   End of the aggregation window (inclusive), `YYYY-MM-DD`
+     * @return ResponseInterface
+     */
+    public function getEmailCampaignStats(
+        int $emailCampaignId,
+        ?string $startDate = null,
+        ?string $endDate = null
+    ): ResponseInterface {
+        $parameters = [];
+
+        if ($startDate !== null) {
+            $parameters['start_date'] = $startDate;
+        }
+
+        if ($endDate !== null) {
+            $parameters['end_date'] = $endDate;
+        }
+
+        return $this->handleResponse(
+            $this->httpGet($this->getBasePath() . '/' . $emailCampaignId . '/stats', $parameters)
+        );
+    }
+
+    public function getAccountId(): int
+    {
+        return $this->accountId;
+    }
+
+    /**
+     * Email campaigns are token-scoped: the path is bare (no `/api/accounts/{account_id}`).
+     */
+    private function getBasePath(): string
+    {
+        return sprintf('%s/api/email_campaigns', $this->getHost());
+    }
+}

--- a/src/DTO/Request/EmailCampaign/CreateEmailCampaign.php
+++ b/src/DTO/Request/EmailCampaign/CreateEmailCampaign.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\DTO\Request\EmailCampaign;
+
+/**
+ * Class CreateEmailCampaign
+ *
+ * Attributes for creating an email campaign. The request body is flat (no wrapper key).
+ * The campaign is always created in the `draft` state; scheduling and starting are
+ * separate lifecycle endpoints.
+ */
+final class CreateEmailCampaign implements EmailCampaignInterface
+{
+    /**
+     * @param string             $name               Campaign name (required)
+     * @param int                $domainId           ID of the verified sending domain, as returned by the Sending Domains endpoints (required)
+     * @param string             $fromLocalPart      Local part (before the @) of the From address (required)
+     * @param TemplateAttributes $templateAttributes Template attributes; `subject` is required on create
+     * @param string|null        $fromDisplayName    Display name shown in the From header
+     * @param ReplyTo|null       $replyTo            Reply-To address parts
+     * @param string|null        $deliveryMode       One of EmailCampaignInterface::DELIVERY_MODE_*
+     * @param array<string, mixed>|null $deliveryOptions Delivery throttling options (`emails_per_hour`), applies to `gradual` mode
+     * @param int[]|null         $contactListIds     IDs of contact lists to send to (the full set — `[]` clears it)
+     * @param int[]|null         $contactSegmentIds  IDs of contact segments to send to (the full set — `[]` clears it)
+     */
+    public function __construct(
+        private string $name,
+        private int $domainId,
+        private string $fromLocalPart,
+        private TemplateAttributes $templateAttributes,
+        private ?string $fromDisplayName = null,
+        private ?ReplyTo $replyTo = null,
+        private ?string $deliveryMode = null,
+        private ?array $deliveryOptions = null,
+        private ?array $contactListIds = null,
+        private ?array $contactSegmentIds = null,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return array_filter(
+            [
+                'name' => $this->name,
+                'domain_id' => $this->domainId,
+                'from_local_part' => $this->fromLocalPart,
+                'from_display_name' => $this->fromDisplayName,
+                'reply_to' => $this->replyTo?->toArray(),
+                'template_attributes' => $this->templateAttributes->toArray(),
+                'delivery_mode' => $this->deliveryMode,
+                'delivery_options' => $this->deliveryOptions,
+                'contact_list_ids' => $this->contactListIds,
+                'contact_segment_ids' => $this->contactSegmentIds,
+            ],
+            fn ($value) => $value !== null
+        );
+    }
+}

--- a/src/DTO/Request/EmailCampaign/EmailCampaignInterface.php
+++ b/src/DTO/Request/EmailCampaign/EmailCampaignInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\DTO\Request\EmailCampaign;
+
+use Mailtrap\DTO\Request\RequestInterface;
+
+interface EmailCampaignInterface extends RequestInterface
+{
+    // Delivery modes (EmailCampaign.delivery_mode)
+    public const DELIVERY_MODE_RAPID = 'rapid';
+    public const DELIVERY_MODE_GRADUAL = 'gradual';
+
+    // Lifecycle states (EmailCampaign.current_state)
+    public const STATE_DRAFT = 'draft';
+    public const STATE_SCHEDULED = 'scheduled';
+    public const STATE_STARTED = 'started';
+    public const STATE_QUEUED = 'queued';
+    public const STATE_PAUSED = 'paused';
+    public const STATE_TERMINATING = 'terminating';
+    public const STATE_UNDER_REVIEW = 'under_review';
+    public const STATE_FINISHED = 'finished';
+    public const STATE_FAILED = 'failed';
+    public const STATE_FAILED_IMMEDIATELY = 'failed_immediately';
+}

--- a/src/DTO/Request/EmailCampaign/ReplyTo.php
+++ b/src/DTO/Request/EmailCampaign/ReplyTo.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\DTO\Request\EmailCampaign;
+
+use Mailtrap\DTO\Request\RequestInterface;
+
+/**
+ * Class ReplyTo
+ *
+ * Reply-To address parts.
+ */
+final class ReplyTo implements RequestInterface
+{
+    /**
+     * @param string|null $displayName Display name shown in the Reply-To header
+     * @param string|null $localPart   Local part (before the @) of the Reply-To address
+     * @param string|null $domain      Domain of the Reply-To address
+     */
+    public function __construct(
+        private ?string $displayName = null,
+        private ?string $localPart = null,
+        private ?string $domain = null,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return array_filter(
+            [
+                'display_name' => $this->displayName,
+                'local_part' => $this->localPart,
+                'domain' => $this->domain,
+            ],
+            fn ($value) => $value !== null
+        );
+    }
+}

--- a/src/DTO/Request/EmailCampaign/TemplateAttributes.php
+++ b/src/DTO/Request/EmailCampaign/TemplateAttributes.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\DTO\Request\EmailCampaign;
+
+use Mailtrap\DTO\Request\RequestInterface;
+
+/**
+ * Class TemplateAttributes
+ *
+ * Inline email template — the campaign's subject and design. The template is always edited
+ * in place: only the provided sub-fields change, omitted sub-fields keep their current value.
+ */
+final class TemplateAttributes implements RequestInterface
+{
+    /**
+     * @param string|null   $subject   Email subject line (required when creating a campaign). Supports `{{tag_name}}` merge tags.
+     * @param string|null   $bodyHtml  HTML body (the design). Required before the campaign can be scheduled or started.
+     *                                 Include an unsubscribe link via the `__unsubscribe_url__` placeholder.
+     * @param string|null   $bodyText  Optional plain-text alternative of the email body
+     * @param string[]|null $mergeTags Bare names of the merge tags referenced in the subject/body (without `{{ }}`).
+     *                                 Replaced as a whole when provided.
+     */
+    public function __construct(
+        private ?string $subject = null,
+        private ?string $bodyHtml = null,
+        private ?string $bodyText = null,
+        private ?array $mergeTags = null,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return array_filter(
+            [
+                'subject' => $this->subject,
+                'body_html' => $this->bodyHtml,
+                'body_text' => $this->bodyText,
+                'merge_tags' => $this->mergeTags,
+            ],
+            fn ($value) => $value !== null
+        );
+    }
+}

--- a/src/DTO/Request/EmailCampaign/UpdateEmailCampaign.php
+++ b/src/DTO/Request/EmailCampaign/UpdateEmailCampaign.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\DTO\Request\EmailCampaign;
+
+use Mailtrap\Exception\RuntimeException;
+
+/**
+ * Class UpdateEmailCampaign
+ *
+ * Attributes for updating a `draft` email campaign. The request body is flat (no wrapper key).
+ * The update is a PATCH: all fields are optional and only provided fields are sent.
+ */
+final class UpdateEmailCampaign implements EmailCampaignInterface
+{
+    /**
+     * @param string|null             $name               Campaign name
+     * @param int|null                $domainId           ID of the verified sending domain, as returned by the Sending Domains endpoints
+     * @param string|null             $fromDisplayName    Display name shown in the From header
+     * @param string|null             $fromLocalPart      Local part (before the @) of the From address
+     * @param string|null             $deliveryMode       One of EmailCampaignInterface::DELIVERY_MODE_*
+     * @param array<string, mixed>|null $deliveryOptions  Delivery throttling options (`emails_per_hour`), applies to `gradual` mode
+     * @param ReplyTo|null            $replyTo            Reply-To address parts
+     * @param TemplateAttributes|null $templateAttributes Template attributes; edited in place, partial
+     * @param int[]|null              $contactListIds     IDs of contact lists to send to (the full set — `[]` clears it)
+     * @param int[]|null              $contactSegmentIds  IDs of contact segments to send to (the full set — `[]` clears it)
+     */
+    public function __construct(
+        private ?string $name = null,
+        private ?int $domainId = null,
+        private ?string $fromDisplayName = null,
+        private ?string $fromLocalPart = null,
+        private ?string $deliveryMode = null,
+        private ?array $deliveryOptions = null,
+        private ?ReplyTo $replyTo = null,
+        private ?TemplateAttributes $templateAttributes = null,
+        private ?array $contactListIds = null,
+        private ?array $contactSegmentIds = null,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        $payload = array_filter(
+            [
+                'name' => $this->name,
+                'domain_id' => $this->domainId,
+                'from_display_name' => $this->fromDisplayName,
+                'from_local_part' => $this->fromLocalPart,
+                'delivery_mode' => $this->deliveryMode,
+                'delivery_options' => $this->deliveryOptions,
+                'reply_to' => $this->replyTo?->toArray(),
+                'template_attributes' => $this->templateAttributes?->toArray(),
+                'contact_list_ids' => $this->contactListIds,
+                'contact_segment_ids' => $this->contactSegmentIds,
+            ],
+            fn ($value) => $value !== null
+        );
+
+        if ($payload === []) {
+            throw new RuntimeException('At least one attribute must be provided to update an email campaign.');
+        }
+
+        return $payload;
+    }
+}

--- a/src/MailtrapGeneralClient.php
+++ b/src/MailtrapGeneralClient.php
@@ -13,6 +13,7 @@ namespace Mailtrap;
  * @method Api\General\Billing       billing(int $accountId)
  * @method Api\General\ApiToken      apiTokens(int $accountId)
  * @method Api\General\Organization  organization(int $organizationId)
+ * @method Api\General\EmailCampaign emailCampaigns(int $accountId)
  *
  * Class MailtrapGeneralClient
  */
@@ -27,5 +28,6 @@ final class MailtrapGeneralClient extends AbstractMailtrapClient
         'billing' => Api\General\Billing::class,
         'apiTokens' => Api\General\ApiToken::class,
         'organization' => Api\General\Organization::class,
+        'emailCampaigns' => Api\General\EmailCampaign::class,
     ];
 }

--- a/tests/Api/General/EmailCampaignTest.php
+++ b/tests/Api/General/EmailCampaignTest.php
@@ -1,0 +1,625 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\Tests\Api\General;
+
+use Mailtrap\Api\AbstractApi;
+use Mailtrap\Api\General\EmailCampaign;
+use Mailtrap\DTO\Request\EmailCampaign\CreateEmailCampaign;
+use Mailtrap\DTO\Request\EmailCampaign\EmailCampaignInterface;
+use Mailtrap\DTO\Request\EmailCampaign\ReplyTo;
+use Mailtrap\DTO\Request\EmailCampaign\TemplateAttributes;
+use Mailtrap\DTO\Request\EmailCampaign\UpdateEmailCampaign;
+use Mailtrap\Exception\HttpClientException;
+use Mailtrap\Exception\RuntimeException;
+use Mailtrap\Helper\ResponseHelper;
+use Mailtrap\Tests\MailtrapTestCase;
+use Nyholm\Psr7\Response;
+
+/**
+ * @covers \Mailtrap\Api\General\EmailCampaign
+ *
+ * Class EmailCampaignTest
+ */
+class EmailCampaignTest extends MailtrapTestCase
+{
+    private const BASE_PATH = AbstractApi::DEFAULT_HOST . '/api/email_campaigns';
+    private const FAKE_DOMAIN_ID = 4321;
+
+    private ?EmailCampaign $emailCampaign;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->emailCampaign = $this->getMockBuilder(EmailCampaign::class)
+            ->onlyMethods(['httpGet', 'httpPost', 'httpPatch', 'httpDelete'])
+            ->setConstructorArgs([$this->getConfigMock(), self::FAKE_ACCOUNT_ID])
+            ->getMock();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->emailCampaign = null;
+        parent::tearDown();
+    }
+
+    public function testGetEmailCampaigns(): void
+    {
+        $this->emailCampaign->expects($this->once())
+            ->method('httpGet')
+            ->with(self::BASE_PATH, [])
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode([
+                        'data' => [$this->getExpectedEmailCampaignResponse()],
+                        'pagination' => $this->getExpectedPagination(),
+                    ])
+                )
+            );
+
+        $response = $this->emailCampaign->getEmailCampaigns();
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertArrayHasKey('data', $responseData);
+        $this->assertArrayHasKey('pagination', $responseData);
+        $this->assertCount(1, $responseData['data']);
+        $this->assertEquals(4567, $responseData['data'][0]['id']);
+        $this->assertEquals(1, $responseData['pagination']['token']);
+    }
+
+    public function testGetEmailCampaignsWithFilters(): void
+    {
+        $perPage = 25;
+        $search = 'spring';
+        $token = 2;
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpGet')
+            ->with(
+                self::BASE_PATH,
+                [
+                    'per_page' => $perPage,
+                    // name filter must serialize to `search`, not `name`
+                    'search' => $search,
+                    'token' => $token,
+                ]
+            )
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode([
+                        'data' => [$this->getExpectedEmailCampaignResponse()],
+                        'pagination' => $this->getExpectedPagination(),
+                    ])
+                )
+            );
+
+        $response = $this->emailCampaign->getEmailCampaigns($perPage, $search, $token);
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertCount(1, $responseData['data']);
+    }
+
+    public function testGetEmailCampaign(): void
+    {
+        $emailCampaignId = 4567;
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpGet')
+            ->with(self::BASE_PATH . '/' . $emailCampaignId)
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['data' => $this->getExpectedEmailCampaignResponse()])
+                )
+            );
+
+        $response = $this->emailCampaign->getEmailCampaign($emailCampaignId);
+        $responseData = ResponseHelper::toArray($response);
+
+        // single-campaign responses are wrapped in a `data` envelope
+        $this->assertArrayHasKey('data', $responseData);
+        $this->assertEquals($emailCampaignId, $responseData['data']['id']);
+        $this->assertEquals(EmailCampaignInterface::STATE_DRAFT, $responseData['data']['current_state']);
+        $this->assertEquals(self::FAKE_DOMAIN_ID, $responseData['data']['domain_id']);
+        $this->assertEquals([55, 56], $responseData['data']['contact_list_ids']);
+        $this->assertEquals([12], $responseData['data']['contact_segment_ids']);
+    }
+
+    public function testGetEmailCampaignFailsWithNotFoundError(): void
+    {
+        $emailCampaignId = 999;
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpGet')
+            ->with(self::BASE_PATH . '/' . $emailCampaignId)
+            ->willReturn(
+                new Response(404, ['Content-Type' => 'application/json'], json_encode(['error' => 'Not Found']))
+            );
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('The requested entity has not been found. Errors: Not Found.');
+
+        $this->emailCampaign->getEmailCampaign($emailCampaignId);
+    }
+
+    public function testCreateEmailCampaign(): void
+    {
+        $createDto = $this->getCreateEmailCampaignDTO();
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                self::BASE_PATH,
+                [],
+                $createDto->toArray()
+            )
+            ->willReturn(
+                new Response(
+                    201,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['data' => $this->getExpectedEmailCampaignResponse()])
+                )
+            );
+
+        $response = $this->emailCampaign->createEmailCampaign($createDto);
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertArrayHasKey('data', $responseData);
+        $this->assertEquals('Spring Sale', $responseData['data']['name']);
+    }
+
+    public function testCreateEmailCampaignSerializesFlatBody(): void
+    {
+        $createDto = $this->getCreateEmailCampaignDTO();
+        $payload = $createDto->toArray();
+
+        // the body is flat — no `email_campaign` wrapper key
+        $this->assertEquals('Spring Sale', $payload['name']);
+        $this->assertEquals(self::FAKE_DOMAIN_ID, $payload['domain_id']);
+        $this->assertEquals('news', $payload['from_local_part']);
+        $this->assertEquals(
+            ['display_name' => 'Acme Support', 'local_part' => 'support', 'domain' => 'acme.com'],
+            $payload['reply_to']
+        );
+        $this->assertEquals(
+            [
+                'subject' => 'Spring is here — 30% off',
+                'body_html' => '<html><body><h1>Hi {{first_name}}!</h1>'
+                    . '<p><a href="__unsubscribe_url__">Unsubscribe</a></p></body></html>',
+                'merge_tags' => ['first_name'],
+            ],
+            $payload['template_attributes']
+        );
+        $this->assertEquals(EmailCampaignInterface::DELIVERY_MODE_GRADUAL, $payload['delivery_mode']);
+        $this->assertEquals(['emails_per_hour' => 1000], $payload['delivery_options']);
+        $this->assertEquals([55, 56], $payload['contact_list_ids']);
+        $this->assertEquals([12], $payload['contact_segment_ids']);
+    }
+
+    public function testCreateEmailCampaignFailsWithValidationErrors(): void
+    {
+        $invalidDto = new CreateEmailCampaign(
+            name: 'Spring Sale',
+            domainId: 999,
+            fromLocalPart: 'news',
+            templateAttributes: new TemplateAttributes(subject: 'Spring is here'),
+        );
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                self::BASE_PATH,
+                [],
+                $invalidDto->toArray()
+            )
+            ->willReturn(
+                new Response(
+                    422,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['errors' => ['domain_id' => ['must exist']]])
+                )
+            );
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('Errors: domain_id -> must exist.');
+
+        $this->emailCampaign->createEmailCampaign($invalidDto);
+    }
+
+    public function testUpdateEmailCampaign(): void
+    {
+        $emailCampaignId = 4567;
+        $updateDto = $this->getUpdateEmailCampaignDTO();
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpPatch')
+            ->with(
+                self::BASE_PATH . '/' . $emailCampaignId,
+                [],
+                $updateDto->toArray()
+            )
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['data' => $this->getExpectedEmailCampaignResponse()])
+                )
+            );
+
+        $response = $this->emailCampaign->updateEmailCampaign($emailCampaignId, $updateDto);
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertArrayHasKey('data', $responseData);
+        $this->assertEquals($emailCampaignId, $responseData['data']['id']);
+    }
+
+    public function testUpdateEmailCampaignSerializesProvidedAttributesOnly(): void
+    {
+        $updateDto = $this->getUpdateEmailCampaignDTO();
+        $payload = $updateDto->toArray();
+
+        $this->assertEquals(
+            [
+                'name' => 'Spring Sale (updated)',
+                'delivery_mode' => EmailCampaignInterface::DELIVERY_MODE_GRADUAL,
+                'delivery_options' => ['emails_per_hour' => 1000],
+                'template_attributes' => ['subject' => 'New subject'],
+                'contact_list_ids' => [55],
+            ],
+            $payload
+        );
+    }
+
+    public function testUpdateEmailCampaignKeepsEmptyAudienceArrays(): void
+    {
+        // `[]` must survive serialization — it clears the audience, unlike an omitted field
+        $payload = (new UpdateEmailCampaign(contactListIds: [], contactSegmentIds: []))->toArray();
+
+        $this->assertEquals(['contact_list_ids' => [], 'contact_segment_ids' => []], $payload);
+    }
+
+    public function testUpdateEmailCampaignRejectsEmptyPayload(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('At least one attribute must be provided to update an email campaign.');
+
+        (new UpdateEmailCampaign())->toArray();
+    }
+
+    public function testDeleteEmailCampaign(): void
+    {
+        $emailCampaignId = 4567;
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpDelete')
+            ->with(self::BASE_PATH . '/' . $emailCampaignId)
+            ->willReturn(new Response(204));
+
+        $response = $this->emailCampaign->deleteEmailCampaign($emailCampaignId);
+
+        $this->assertEquals(204, $response->getStatusCode());
+        $this->assertEmpty($response->getBody()->__toString());
+    }
+
+    public function testStartEmailCampaign(): void
+    {
+        $emailCampaignId = 4567;
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpPost')
+            ->with(self::BASE_PATH . '/' . $emailCampaignId . '/start')
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['data' => $this->getExpectedEmailCampaignResponse(
+                        EmailCampaignInterface::STATE_QUEUED
+                    )])
+                )
+            );
+
+        $response = $this->emailCampaign->startEmailCampaign($emailCampaignId);
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertEquals(EmailCampaignInterface::STATE_QUEUED, $responseData['data']['current_state']);
+    }
+
+    public function testScheduleEmailCampaign(): void
+    {
+        $emailCampaignId = 4567;
+        $datetime = '2026-06-01T09:00:00.000Z';
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                self::BASE_PATH . '/' . $emailCampaignId . '/schedule',
+                [],
+                ['datetime' => $datetime]
+            )
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['data' => $this->getExpectedEmailCampaignResponse(
+                        EmailCampaignInterface::STATE_SCHEDULED
+                    )])
+                )
+            );
+
+        $response = $this->emailCampaign->scheduleEmailCampaign($emailCampaignId, $datetime);
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertEquals(EmailCampaignInterface::STATE_SCHEDULED, $responseData['data']['current_state']);
+    }
+
+    public function testScheduleEmailCampaignAcceptsDateTime(): void
+    {
+        $emailCampaignId = 4567;
+        $datetime = new \DateTimeImmutable('2026-06-01 09:00:00', new \DateTimeZone('UTC'));
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                self::BASE_PATH . '/' . $emailCampaignId . '/schedule',
+                [],
+                ['datetime' => '2026-06-01T09:00:00+00:00']
+            )
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['data' => $this->getExpectedEmailCampaignResponse(
+                        EmailCampaignInterface::STATE_SCHEDULED
+                    )])
+                )
+            );
+
+        $this->emailCampaign->scheduleEmailCampaign($emailCampaignId, $datetime);
+    }
+
+    public function testCancelEmailCampaign(): void
+    {
+        $emailCampaignId = 4567;
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpPost')
+            ->with(self::BASE_PATH . '/' . $emailCampaignId . '/cancel')
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['data' => $this->getExpectedEmailCampaignResponse()])
+                )
+            );
+
+        $response = $this->emailCampaign->cancelEmailCampaign($emailCampaignId);
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertEquals(EmailCampaignInterface::STATE_DRAFT, $responseData['data']['current_state']);
+    }
+
+    public function testCancelEmailCampaignFailsWhenNotScheduled(): void
+    {
+        $emailCampaignId = 4567;
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpPost')
+            ->with(self::BASE_PATH . '/' . $emailCampaignId . '/cancel')
+            ->willReturn(
+                new Response(
+                    422,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['errors' => 'Campaign is not scheduled'])
+                )
+            );
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('Errors: Campaign is not scheduled.');
+
+        $this->emailCampaign->cancelEmailCampaign($emailCampaignId);
+    }
+
+    public function testTerminateEmailCampaign(): void
+    {
+        $emailCampaignId = 4567;
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpPost')
+            ->with(self::BASE_PATH . '/' . $emailCampaignId . '/terminate')
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['data' => $this->getExpectedEmailCampaignResponse(
+                        EmailCampaignInterface::STATE_TERMINATING
+                    )])
+                )
+            );
+
+        $response = $this->emailCampaign->terminateEmailCampaign($emailCampaignId);
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertEquals(EmailCampaignInterface::STATE_TERMINATING, $responseData['data']['current_state']);
+    }
+
+    public function testResetEmailCampaign(): void
+    {
+        $emailCampaignId = 4567;
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpPost')
+            ->with(self::BASE_PATH . '/' . $emailCampaignId . '/reset')
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['data' => $this->getExpectedEmailCampaignResponse()])
+                )
+            );
+
+        $response = $this->emailCampaign->resetEmailCampaign($emailCampaignId);
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertEquals(EmailCampaignInterface::STATE_DRAFT, $responseData['data']['current_state']);
+    }
+
+    public function testGetEmailCampaignStats(): void
+    {
+        $emailCampaignId = 4567;
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpGet')
+            ->with(self::BASE_PATH . '/' . $emailCampaignId . '/stats', [])
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['data' => $this->getExpectedStatsResponse()])
+                )
+            );
+
+        $response = $this->emailCampaign->getEmailCampaignStats($emailCampaignId);
+        $responseData = ResponseHelper::toArray($response);
+
+        // stats are wrapped in a `data` envelope
+        $this->assertArrayHasKey('data', $responseData);
+        $this->assertEquals(1450, $responseData['data']['delivery_count']);
+        $this->assertEquals(0.9667, $responseData['data']['delivery_rate']);
+    }
+
+    public function testGetEmailCampaignStatsWithDateRange(): void
+    {
+        $emailCampaignId = 4567;
+        $startDate = '2026-05-01';
+        $endDate = '2026-05-31';
+
+        $this->emailCampaign->expects($this->once())
+            ->method('httpGet')
+            ->with(
+                self::BASE_PATH . '/' . $emailCampaignId . '/stats',
+                ['start_date' => $startDate, 'end_date' => $endDate]
+            )
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['data' => $this->getExpectedStatsResponse()])
+                )
+            );
+
+        $response = $this->emailCampaign->getEmailCampaignStats($emailCampaignId, $startDate, $endDate);
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertEquals(1500, $responseData['data']['sent_count']);
+    }
+
+    public function testGetAccountId(): void
+    {
+        $this->assertEquals(self::FAKE_ACCOUNT_ID, $this->emailCampaign->getAccountId());
+    }
+
+    private function getCreateEmailCampaignDTO(): CreateEmailCampaign
+    {
+        return new CreateEmailCampaign(
+            name: 'Spring Sale',
+            domainId: self::FAKE_DOMAIN_ID,
+            fromLocalPart: 'news',
+            templateAttributes: new TemplateAttributes(
+                subject: 'Spring is here — 30% off',
+                bodyHtml: '<html><body><h1>Hi {{first_name}}!</h1>'
+                    . '<p><a href="__unsubscribe_url__">Unsubscribe</a></p></body></html>',
+                mergeTags: ['first_name'],
+            ),
+            fromDisplayName: 'Acme Marketing',
+            replyTo: new ReplyTo(displayName: 'Acme Support', localPart: 'support', domain: 'acme.com'),
+            deliveryMode: EmailCampaignInterface::DELIVERY_MODE_GRADUAL,
+            deliveryOptions: ['emails_per_hour' => 1000],
+            contactListIds: [55, 56],
+            contactSegmentIds: [12],
+        );
+    }
+
+    private function getUpdateEmailCampaignDTO(): UpdateEmailCampaign
+    {
+        return new UpdateEmailCampaign(
+            name: 'Spring Sale (updated)',
+            deliveryMode: EmailCampaignInterface::DELIVERY_MODE_GRADUAL,
+            deliveryOptions: ['emails_per_hour' => 1000],
+            templateAttributes: new TemplateAttributes(subject: 'New subject'),
+            contactListIds: [55],
+        );
+    }
+
+    private function getExpectedEmailCampaignResponse(
+        string $currentState = EmailCampaignInterface::STATE_DRAFT
+    ): array {
+        return [
+            'id' => 4567,
+            'domain_id' => self::FAKE_DOMAIN_ID,
+            'domain_name' => 'acme.com',
+            'name' => 'Spring Sale',
+            'from_local_part' => 'news',
+            'from_display_name' => 'Acme Marketing',
+            'reply_to' => ['display_name' => 'Acme Support', 'local_part' => 'support', 'domain' => 'acme.com'],
+            'current_state' => $currentState,
+            'current_state_metadata' => $currentState === EmailCampaignInterface::STATE_SCHEDULED
+                ? ['scheduled_at' => '2026-06-01T09:00:00.000Z']
+                : [],
+            'created_at' => '2026-05-01T10:15:00.000Z',
+            'updated_at' => '2026-05-02T09:00:00.000Z',
+            'last_started_at' => null,
+            'recipient_total_count' => null,
+            'contact_list_ids' => [55, 56],
+            'contact_segment_ids' => [12],
+            'delivery_mode' => 'rapid',
+            'delivery_options' => ['emails_per_hour' => null],
+            'template' => [
+                'id' => 789,
+                'subject' => 'Spring is here — 30% off',
+                'merge_tags' => ['first_name'],
+                'body_html' => '<html><body><h1>Hi {{first_name}}!</h1>'
+                    . '<p><a href="__unsubscribe_url__">Unsubscribe</a></p></body></html>',
+                'body_text' => null,
+            ],
+        ];
+    }
+
+    private function getExpectedStatsResponse(): array
+    {
+        return [
+            'delivery_count' => 1450,
+            'open_count' => 820,
+            'click_count' => 310,
+            'bounce_count' => 30,
+            'unsubscription_count' => 12,
+            'sent_count' => 1500,
+            'spam_count' => 5,
+            'delivery_rate' => 0.9667,
+            'open_rate' => 0.5655,
+            'click_rate' => 0.2138,
+            'bounce_rate' => 0.02,
+            'spam_rate' => 0.0033,
+            'unsubscription_rate' => 0.0083,
+        ];
+    }
+
+    private function getExpectedPagination(): array
+    {
+        return [
+            'token' => 1,
+            'prev_token' => null,
+            'next_token' => 2,
+            'first_url' => 'https://mailtrap.io/api/email_campaigns?per_page=50&token=1',
+            'prev_url' => null,
+            'current_url' => 'https://mailtrap.io/api/email_campaigns?per_page=50&token=1',
+            'next_url' => 'https://mailtrap.io/api/email_campaigns?per_page=50&token=2',
+        ];
+    }
+}

--- a/tests/MailtrapGeneralClientTest.php
+++ b/tests/MailtrapGeneralClientTest.php
@@ -28,7 +28,7 @@ class MailtrapGeneralClientTest extends MailtrapClientTestCase
     {
         foreach (MailtrapGeneralClient::API_MAPPING as $key => $item) {
             yield match ($key) {
-                'permissions', 'users', 'contacts', 'emailTemplates', 'billing', 'apiTokens' => [new $item($this->getConfigMock(), self::FAKE_ACCOUNT_ID)],
+                'permissions', 'users', 'contacts', 'emailTemplates', 'billing', 'apiTokens', 'emailCampaigns' => [new $item($this->getConfigMock(), self::FAKE_ACCOUNT_ID)],
                 'organization' => [new $item($this->getConfigMock(), self::FAKE_ORGANIZATION_ID)],
                 default => [new $item($this->getConfigMock())],
             };


### PR DESCRIPTION
> **Draft** until the server-side Email Campaigns API changes are released.

## Motivation

MT-22401

Port the Email Campaigns public API (MT-21113) to the PHP SDK.

## Changes

- Add `emailCampaigns()` to the General client with the full contract: list (per_page/search/token), get, create, update, delete (204), the five lifecycle actions (`start`, `schedule`, `cancel`, `terminate`, `reset`), and stats with an optional date range
- Typed request DTOs per the published OpenAPI schema: flat request bodies, integer `domainId` (a Sending Domains endpoint id), new `TemplateAttributes` (`subject`/`bodyHtml`/`bodyText`/`mergeTags`) and `ReplyTo` DTOs, audience id arrays (empty array clears the audience), `rapid`/`gradual` delivery modes, 10-value state constants
- Full-lifecycle example in `examples/email-campaigns/all.php` + README/CHANGELOG entries

## How to test

- [ ] Run `examples/email-campaigns/all.php` with a real API token and a verified sending domain — create a draft, update design/audience, schedule + cancel, fetch stats, delete
- [ ] Verify single-campaign responses expose the `data` payload and a lifecycle 422 surfaces the API error message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Email Campaigns API support.
  * List, view, create, update, and delete campaigns.
  * Manage campaign lifecycles with start, schedule, cancel, terminate, and reset actions.
  * Retrieve campaign performance statistics with optional date ranges.
  * Added support for campaign delivery settings, templates, reply-to details, contact lists, and segments.
  * Added runnable examples and usage documentation.

* **Tests**
  * Added comprehensive coverage for campaign management, lifecycle actions, validation, serialization, and statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


