### PR TITLE
MT-23076: support api token expiration in create and reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Contact management:
 
 General API:
 - Templates CRUD – [`templates/all.php`](examples/templates/all.php)
+- API tokens CRUD – [`api-tokens/all.php`](examples/api-tokens/all.php)
 - Billing info – [`general/billing.php`](examples/general/billing.php)
 - Accounts info – [`general/accounts.php`](examples/general/accounts.php)
 - Permissions listing – [`general/permissions.php`](examples/general/permissions.php)

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,6 +54,7 @@ Central index of runnable example scripts demonstrating Mailtrap PHP SDK feature
 ### 6. General API
 | Purpose | File |
 |---------|------|
+| API tokens CRUD | [`api-tokens/all.php`](api-tokens/all.php) |
 | Accounts info | [`general/accounts.php`](general/accounts.php) |
 | Billing info | [`general/billing.php`](general/billing.php) |
 | Permissions listing | [`general/permissions.php`](general/permissions.php) |

--- a/examples/api-tokens/all.php
+++ b/examples/api-tokens/all.php
@@ -1,6 +1,7 @@
 <?php
 
 use Mailtrap\Config;
+use Mailtrap\DTO\Request\ApiToken\TokenExpiration;
 use Mailtrap\DTO\Request\Permission\CreateOrUpdatePermission;
 use Mailtrap\DTO\Request\Permission\PermissionInterface;
 use Mailtrap\DTO\Request\Permission\Permissions;
@@ -44,6 +45,10 @@ try {
 /**
  * Create a new API token. The full token value is returned only in this response.
  *
+ * Expiration is optional: omit the argument for the server default (a 1-year default is being
+ * rolled out), pass TokenExpiration::at(...) for a specific ISO 8601 date-time, or
+ * TokenExpiration::never() for a token that never expires.
+ *
  * POST https://mailtrap.io/api/accounts/{account_id}/api_tokens
  */
 try {
@@ -55,7 +60,11 @@ try {
         )
     );
 
-    $response = $apiTokens->createApiToken('My new API token', $permissions);
+    $response = $apiTokens->createApiToken(
+        'My new API token',
+        $permissions,
+        TokenExpiration::at('2027-06-01T00:00:00Z') // or TokenExpiration::never(), or omit
+    );
 
     var_dump(ResponseHelper::toArray($response));
 } catch (Exception $e) {
@@ -65,12 +74,16 @@ try {
 /**
  * Reset an API token by ID. Returns a new token value; the previous value stops working.
  *
+ * Expiration of the new token is optional: omit the argument for the server default (a 1-year
+ * default is being rolled out), pass TokenExpiration::at(...) for a specific ISO 8601 date-time,
+ * or TokenExpiration::never() for a token that never expires.
+ *
  * POST https://mailtrap.io/api/accounts/{account_id}/api_tokens/{id}/reset
  */
 try {
     $apiTokenId = 1;
 
-    $response = $apiTokens->resetApiToken($apiTokenId);
+    $response = $apiTokens->resetApiToken($apiTokenId, TokenExpiration::never());
 
     var_dump(ResponseHelper::toArray($response));
 } catch (Exception $e) {

--- a/src/Api/General/ApiToken.php
+++ b/src/Api/General/ApiToken.php
@@ -6,6 +6,7 @@ namespace Mailtrap\Api\General;
 
 use Mailtrap\Api\AbstractApi;
 use Mailtrap\ConfigInterface;
+use Mailtrap\DTO\Request\ApiToken\TokenExpiration;
 use Mailtrap\DTO\Request\Permission\Permissions;
 use Psr\Http\Message\ResponseInterface;
 
@@ -47,19 +48,29 @@ class ApiToken extends AbstractApi implements GeneralInterface
     /**
      * Create a new API token. The full token value is returned only in this response.
      *
-     * @param string      $name
-     * @param Permissions $permissions
+     * @param string               $name
+     * @param Permissions          $permissions
+     * @param TokenExpiration|null $expiration Optional token expiration as an ISO 8601 date-time.
+     *                                         Omit for the server default (a 1-year default is being rolled out).
+     *                                         Use TokenExpiration::never() for a token that never expires.
+     *                                         Past or more-than-5-years-ahead values are rejected with 422.
      *
      * @return ResponseInterface
      */
-    public function createApiToken(string $name, Permissions $permissions): ResponseInterface
+    public function createApiToken(string $name, Permissions $permissions, ?TokenExpiration $expiration = null): ResponseInterface
     {
+        $body = [
+            'name' => $name,
+            'resources' => $permissions->toPayload(),
+        ];
+
+        if ($expiration !== null) {
+            $body['expires_at'] = $expiration->getValue();
+        }
+
         return $this->handleResponse($this->httpPost(
             path: $this->getBasePath(),
-            body: [
-                'name' => $name,
-                'resources' => $permissions->toPayload(),
-            ]
+            body: $body
         ));
     }
 

--- a/src/Api/General/ApiToken.php
+++ b/src/Api/General/ApiToken.php
@@ -90,14 +90,28 @@ class ApiToken extends AbstractApi implements GeneralInterface
     /**
      * Reset an API token by ID. Returns a new token value; the previous value stops working.
      *
-     * @param int $apiTokenId
+     * @param int                  $apiTokenId
+     * @param TokenExpiration|null $expiration Optional expiration of the new token as an ISO 8601 date-time.
+     *                                         Omit for the server default (a 1-year default is being rolled out).
+     *                                         Use TokenExpiration::never() for a token that never expires.
+     *                                         Past or more-than-5-years-ahead values are rejected with 422.
+     *
      * @return ResponseInterface
      */
-    public function resetApiToken(int $apiTokenId): ResponseInterface
+    public function resetApiToken(int $apiTokenId, ?TokenExpiration $expiration = null): ResponseInterface
     {
-        return $this->handleResponse(
-            $this->httpPost($this->getBasePath() . '/' . $apiTokenId . '/reset')
-        );
+        $path = $this->getBasePath() . '/' . $apiTokenId . '/reset';
+
+        if ($expiration === null) {
+            return $this->handleResponse(
+                $this->httpPost($path)
+            );
+        }
+
+        return $this->handleResponse($this->httpPost(
+            path: $path,
+            body: ['expires_at' => $expiration->getValue()]
+        ));
     }
 
     public function getAccountId(): int

--- a/src/DTO/Request/ApiToken/TokenExpiration.php
+++ b/src/DTO/Request/ApiToken/TokenExpiration.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mailtrap\DTO\Request\ApiToken;
+
+use DateTimeInterface;
+
+/**
+ * Optional token expiration as an ISO 8601 date-time.
+ * Omit the argument for the server default (a 1-year default is being rolled out).
+ * Use TokenExpiration::never() for a token that never expires.
+ * Past or more-than-5-years-ahead values are rejected with 422.
+ *
+ * Class TokenExpiration
+ */
+final class TokenExpiration
+{
+    private function __construct(private ?string $value)
+    {
+    }
+
+    /**
+     * Expire the token at the given ISO 8601 date-time.
+     *
+     * @param DateTimeInterface|string $value
+     *
+     * @return self
+     */
+    public static function at(DateTimeInterface|string $value): self
+    {
+        return new self(
+            $value instanceof DateTimeInterface ? $value->format(DateTimeInterface::ATOM) : $value
+        );
+    }
+
+    /**
+     * Token never expires.
+     *
+     * @return self
+     */
+    public static function never(): self
+    {
+        return new self(null);
+    }
+
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Api/General/ApiTokenTest.php
+++ b/tests/Api/General/ApiTokenTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Mailtrap\Tests\Api\General;
 
+use DateTimeImmutable;
 use Mailtrap\Api\AbstractApi;
 use Mailtrap\Api\General\ApiToken;
+use Mailtrap\DTO\Request\ApiToken\TokenExpiration;
 use Mailtrap\DTO\Request\Permission\CreateOrUpdatePermission;
 use Mailtrap\DTO\Request\Permission\PermissionInterface;
 use Mailtrap\DTO\Request\Permission\Permissions;
@@ -149,6 +151,149 @@ class ApiTokenTest extends MailtrapTestCase
         $this->assertEquals('fresh-secret-token-value', $responseData['token']);
     }
 
+    public function testCreateApiTokenWithNeverExpiration(): void
+    {
+        $name = 'My API token';
+
+        $this->apiToken->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/api_tokens',
+                [],
+                [
+                    'name' => $name,
+                    'resources' => [
+                        [
+                            'resource_id' => (string) self::FAKE_ACCOUNT_ID,
+                            'resource_type' => PermissionInterface::TYPE_ACCOUNT,
+                            'access_level' => '1000',
+                        ],
+                    ],
+                    'expires_at' => null,
+                ]
+            )
+            ->willReturn(
+                new Response(
+                    201,
+                    ['Content-Type' => 'application/json'],
+                    json_encode($this->getExpectedApiTokenResponse() + ['token' => 'fresh-secret-token-value'])
+                )
+            );
+
+        $this->apiToken->createApiToken($name, $this->getPermissions(), TokenExpiration::never());
+    }
+
+    public function testCreateApiTokenWithExpirationDateString(): void
+    {
+        $name = 'My API token';
+
+        $this->apiToken->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/api_tokens',
+                [],
+                [
+                    'name' => $name,
+                    'resources' => [
+                        [
+                            'resource_id' => (string) self::FAKE_ACCOUNT_ID,
+                            'resource_type' => PermissionInterface::TYPE_ACCOUNT,
+                            'access_level' => '1000',
+                        ],
+                    ],
+                    'expires_at' => '2027-06-01T00:00:00Z',
+                ]
+            )
+            ->willReturn(
+                new Response(
+                    201,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(
+                        array_merge($this->getExpectedApiTokenResponse(), ['expires_at' => '2027-06-01T00:00:00Z'])
+                            + ['token' => 'fresh-secret-token-value']
+                    )
+                )
+            );
+
+        $response = $this->apiToken->createApiToken($name, $this->getPermissions(), TokenExpiration::at('2027-06-01T00:00:00Z'));
+        $responseData = ResponseHelper::toArray($response);
+
+        $this->assertEquals('2027-06-01T00:00:00Z', $responseData['expires_at']);
+    }
+
+    public function testCreateApiTokenWithExpirationDateTimeObject(): void
+    {
+        $name = 'My API token';
+
+        $this->apiToken->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/api_tokens',
+                [],
+                [
+                    'name' => $name,
+                    'resources' => [
+                        [
+                            'resource_id' => (string) self::FAKE_ACCOUNT_ID,
+                            'resource_type' => PermissionInterface::TYPE_ACCOUNT,
+                            'access_level' => '1000',
+                        ],
+                    ],
+                    'expires_at' => '2027-06-01T00:00:00+00:00',
+                ]
+            )
+            ->willReturn(
+                new Response(
+                    201,
+                    ['Content-Type' => 'application/json'],
+                    json_encode($this->getExpectedApiTokenResponse() + ['token' => 'fresh-secret-token-value'])
+                )
+            );
+
+        $this->apiToken->createApiToken(
+            $name,
+            $this->getPermissions(),
+            TokenExpiration::at(new DateTimeImmutable('2027-06-01T00:00:00+00:00'))
+        );
+    }
+
+    public function testCreateApiTokenFailsWithInvalidExpiration(): void
+    {
+        $this->apiToken->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/api_tokens',
+                [],
+                [
+                    'name' => 'My API token',
+                    'resources' => [
+                        [
+                            'resource_id' => (string) self::FAKE_ACCOUNT_ID,
+                            'resource_type' => PermissionInterface::TYPE_ACCOUNT,
+                            'access_level' => '1000',
+                        ],
+                    ],
+                    'expires_at' => '2020-01-01T00:00:00Z',
+                ]
+            )
+            ->willReturn(
+                new Response(
+                    422,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['errors' => ['expires_at' => ['must be in the future']]])
+                )
+            );
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('must be in the future');
+
+        $this->apiToken->createApiToken(
+            'My API token',
+            $this->getPermissions(),
+            TokenExpiration::at('2020-01-01T00:00:00Z')
+        );
+    }
+
     public function testCreateApiTokenFailsWithoutPermissions(): void
     {
         $this->expectException(RuntimeException::class);
@@ -177,7 +322,11 @@ class ApiTokenTest extends MailtrapTestCase
 
         $this->apiToken->expects($this->once())
             ->method('httpPost')
-            ->with(AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/api_tokens/' . $apiTokenId . '/reset')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/api_tokens/' . $apiTokenId . '/reset',
+                [],
+                null // no expiration argument -> no request body at all
+            )
             ->willReturn(
                 new Response(
                     200,
@@ -192,6 +341,78 @@ class ApiTokenTest extends MailtrapTestCase
         $this->assertArrayHasKey('id', $responseData);
         $this->assertArrayHasKey('token', $responseData);
         $this->assertEquals('rotated-secret-token-value', $responseData['token']);
+    }
+
+    public function testResetApiTokenWithNeverExpiration(): void
+    {
+        $apiTokenId = 1;
+
+        $this->apiToken->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/api_tokens/' . $apiTokenId . '/reset',
+                [],
+                ['expires_at' => null]
+            )
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode($this->getExpectedApiTokenResponse() + ['token' => 'rotated-secret-token-value'])
+                )
+            );
+
+        $this->apiToken->resetApiToken($apiTokenId, TokenExpiration::never());
+    }
+
+    public function testResetApiTokenWithExpirationDateString(): void
+    {
+        $apiTokenId = 1;
+
+        $this->apiToken->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/api_tokens/' . $apiTokenId . '/reset',
+                [],
+                ['expires_at' => '2027-06-01T00:00:00Z']
+            )
+            ->willReturn(
+                new Response(
+                    200,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(
+                        array_merge($this->getExpectedApiTokenResponse(), ['expires_at' => '2027-06-01T00:00:00Z'])
+                            + ['token' => 'rotated-secret-token-value']
+                    )
+                )
+            );
+
+        $this->apiToken->resetApiToken($apiTokenId, TokenExpiration::at('2027-06-01T00:00:00Z'));
+    }
+
+    public function testResetApiTokenFailsWithInvalidExpiration(): void
+    {
+        $apiTokenId = 1;
+
+        $this->apiToken->expects($this->once())
+            ->method('httpPost')
+            ->with(
+                AbstractApi::DEFAULT_HOST . '/api/accounts/' . self::FAKE_ACCOUNT_ID . '/api_tokens/' . $apiTokenId . '/reset',
+                [],
+                ['expires_at' => '2020-01-01T00:00:00Z']
+            )
+            ->willReturn(
+                new Response(
+                    422,
+                    ['Content-Type' => 'application/json'],
+                    json_encode(['errors' => ['expires_at' => ['must be in the future']]])
+                )
+            );
+
+        $this->expectException(HttpClientException::class);
+        $this->expectExceptionMessage('must be in the future');
+
+        $this->apiToken->resetApiToken($apiTokenId, TokenExpiration::at('2020-01-01T00:00:00Z'));
     }
 
     public function testResetApiTokenFailsWhenAlreadyReset(): void


### PR DESCRIPTION
## Motivation

[MT-23076](https://railsware.atlassian.net/browse/MT-23076)

The API token endpoints now accept an optional `expires_at` value. This exposes it in the SDK so users can create or reset tokens with a specific expiry, no expiry, or the server default.

## Changes

- new `TokenExpiration` value object (`src/DTO/Request/ApiToken/TokenExpiration.php`) with `TokenExpiration::at(DateTimeInterface|string)` and `TokenExpiration::never()` named constructors
- `createApiToken` (OpenAPI `createApiToken`, `CreateApiTokenRequest.expires_at`) takes an optional `?TokenExpiration $expiration` – argument omitted → no `expires_at` key in the body (server default, a 1-year default is being rolled out), `never()` → `"expires_at": null` (never expires), `at(...)` → the given ISO 8601 date-time
- `resetApiToken` (OpenAPI `resetApiToken`, request body is now optional with the same `expires_at` param) takes the same optional argument – without it the request still has no body at all, unchanged from the previous release
- no client-side date validation – past, unparseable, or more-than-5-years-ahead values are rejected by the server with 422 and surface as `HttpClientException`
- `examples/api-tokens/all.php` shows the new argument; README and examples index now list the api-tokens example under General API

## How to test

- [ ] `createApiToken($name, $permissions)` without the new argument – the request body contains only `name` and `resources` (no `expires_at` key), the token is created
- [ ] `resetApiToken($id)` without the new argument – the request is sent with no body at all, exactly as before this change, and returns the new token value
- [ ] `createApiToken($name, $permissions, TokenExpiration::at('2027-06-01T00:00:00Z'))` – the body contains `"expires_at": "2027-06-01T00:00:00Z"` and the response echoes that expiry
- [ ] `TokenExpiration::at(new DateTimeImmutable('2027-06-01T00:00:00+00:00'))` – the DateTime is serialized as an ISO 8601 string in the body
- [ ] `createApiToken(..., TokenExpiration::never())` and `resetApiToken($id, TokenExpiration::never())` – the body contains `"expires_at": null` and the response token has `expires_at: null`
- [ ] `TokenExpiration::at('2020-01-01T00:00:00Z')` (a past date) on create or reset – the server responds 422 and the SDK throws `HttpClientException` with the server error message

## Companion PRs

- falcon – railsware/falcon#10763
- spec – mailtrap/mailtrap-openapi#51
- nodejs – mailtrap/mailtrap-nodejs#149
- mcp – mailtrap/mailtrap-mcp#136
- python – mailtrap/mailtrap-python#77
- ruby – mailtrap/mailtrap-ruby#122
- java – mailtrap/mailtrap-java#68
- dotnet – mailtrap/mailtrap-dotnet#253
- go – mailtrap/mailtrap-go#28
- cli – mailtrap/mailtrap-cli#12

Caveat: release/merge only after falcon deploys MT-23076 and zap_api_token_expiration is enabled in production.

[MT-23076]: https://railsware.atlassian.net/browse/MT-23076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
